### PR TITLE
Fix song template to handle releases without a project

### DIFF
--- a/src/_layouts/song.njk
+++ b/src/_layouts/song.njk
@@ -6,17 +6,18 @@
             <a href="/songs/">« All Songs</a>
         </p>
         <h2>{{ title }}</h2>
-        {% if released %}
+        {% set releasedWithProjects = released | selectattr("project") | list %}
+        {% if releasedWithProjects | length %}
         <div class="song-projects">
             <strong>Appears in:</strong>
             <ul>
-            {% for rel in released %}
+            {% for rel in releasedWithProjects %}
                 {% set project = collections.projects | getProjectByName(rel.project) %}
                 <li><a href="/projects/{{ rel.project }}/">{{ project.title }}</a></li>
             {% endfor %}
             </ul>
         </div>
-        {% else %}
+        {% elif not released %}
         <p><em>This song is not released yet, but I've been singing it out in the world. Feel free to learn it and sing it with your friends!</em></p>
         {% endif %}
         <div class="song-lyrics">
@@ -25,8 +26,12 @@
         {% if released %}
           {% for rel in released %}
             {% if rel.bandcampTrackId %}
-              {% set project = collections.projects | getProjectByName(rel.project) %}
-              <iframe style="border: 0; width: 250px; height: 250px;" src="https://bandcamp.com/EmbeddedPlayer/album={{ project.bandcampID }}/size=large/bgcol=ffffff/linkcol=0687f5/minimal=true/track={{ rel.bandcampTrackId }}/transparent=true/" seamless><a href="https://emmaazelborn.bandcamp.com{{ project.bandcampUrl }}">{{ title }} by Emma Azelborn</a></iframe>
+              {% if rel.project %}
+                {% set project = collections.projects | getProjectByName(rel.project) %}
+                <iframe style="border: 0; width: 250px; height: 250px;" src="https://bandcamp.com/EmbeddedPlayer/album={{ project.bandcampID }}/size=large/bgcol=ffffff/linkcol=0687f5/minimal=true/track={{ rel.bandcampTrackId }}/transparent=true/" seamless><a href="https://emmaazelborn.bandcamp.com{{ project.bandcampUrl }}">{{ title }} by Emma Azelborn</a></iframe>
+              {% else %}
+                <iframe style="border: 0; width: 250px; height: 250px;" src="https://bandcamp.com/EmbeddedPlayer/track={{ rel.bandcampTrackId }}/size=large/bgcol=ffffff/linkcol=0687f5/minimal=true/transparent=true/" seamless><a href="https://emmaazelborn.bandcamp.com">{{ title }} by Emma Azelborn</a></iframe>
+              {% endif %}
             {% endif %}
           {% endfor %}
         {% elif voiceMemo %}


### PR DESCRIPTION
The bandcamp embed and "Appears in" section both assumed every released
entry would have a project. Guard project lookups with rel.project checks
and use a track-only embed URL when no project is associated.

https://claude.ai/code/session_01297NwCyPyJgnjfSMdGsPfz