### PR TITLE
Fix song template crash when release has no project

### DIFF
--- a/src/_layouts/song.njk
+++ b/src/_layouts/song.njk
@@ -6,7 +6,7 @@
             <a href="/songs/">« All Songs</a>
         </p>
         <h2>{{ title }}</h2>
-        {% set releasedWithProjects = released | selectattr("project") | list %}
+        {% set releasedWithProjects = (released or []) | selectattr("project") | list %}
         {% if releasedWithProjects | length %}
         <div class="song-projects">
             <strong>Appears in:</strong>


### PR DESCRIPTION
## Summary

- Guard the "Appears in" section to only show projects when a released entry actually has a `project` field
- Use a track-only Bandcamp embed URL (`/EmbeddedPlayer/track=...`) when a release has a `bandcampTrackId` but no associated project
- Fix `selectattr` crash by defaulting `released` to `[]` when undefined, so songs with no `released` key don't break the build

## Test plan

- [ ] Build completes without errors
- [ ] "We Are Here & We Are Rising" page renders with the Bandcamp embed and no "Appears in" section
- [ ] Songs with no `released` key still show the "not released yet" message
- [ ] Songs with project-linked releases still show the "Appears in" section correctly

https://claude.ai/code/session_01297NwCyPyJgnjfSMdGsPfz