### PR TITLE
Document serve-worktree shell function for previewing Claude worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,16 @@ Always run `npm run lint && npm run format:check` before finalizing any changes.
 
 **Once a URL has been deployed, it must never change.** This applies to all content: posts (`p/<slug>/`), songs, projects, and static assets. Renaming files, changing slugs, restructuring directories, or altering permalink patterns are all high-risk operations. If a structural change is unavoidable, add Eleventy redirects rather than removing the old URL.
 
+### Previewing Claude worktree branches
+
+To run a dev server for a Claude-managed worktree branch without checking it out, use the `serve-worktree` shell function (defined in `~/.bash_profile`):
+
+```bash
+serve-worktree claude/cranky-grothendieck-ec31fa
+```
+
+This serves the worktree from a deterministic port derived from the branch name (range 3000–9999), so multiple worktrees can run simultaneously. The port is printed on start.
+
 ## Architecture
 
 This is an [Eleventy](https://www.11ty.dev/) static site. Source is in `src/`, output goes to `dist/`. Templates use Nunjucks (`.njk`); Markdown also runs through Nunjucks. Layouts and includes are both in `src/_layouts/`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ npm run serve
 
 The site will be available at `http://localhost:8080`
 
+#### Previewing Claude worktree branches
+
+Claude Code manages changes in git worktrees under `.claude/worktrees/`. To preview a worktree branch without checking it out, use the `serve-worktree` shell function (defined in `~/.bash_profile`):
+
+```bash
+serve-worktree claude/cranky-grothendieck-ec31fa
+```
+
+Each worktree gets a deterministic port in the 3000–9999 range based on its branch name, so multiple can run at once.
+
 ### Building for Production
 
 Generate a production build:


### PR DESCRIPTION
## Summary

- Adds a `serve-worktree` bash function to `~/.bash_profile` that takes a Claude worktree branch name (e.g. `claude/cranky-grothendieck-ec31fa`) and runs `npm run serve` from the worktree directory on a deterministic port
- Port is derived from the branch name (range 3000–9999) so multiple worktrees can run simultaneously
- Documents the function in both `CLAUDE.md` and `README.md`

## What changed and why

Git won't let you check out a branch that's already checked out in a worktree. The `serve-worktree` function lets you preview any Claude-managed worktree branch by running the dev server directly from the worktree path, without needing to check it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)