### PR TITLE
Show project images on event cards

### DIFF
--- a/eleventy/filters/calendar.js
+++ b/eleventy/filters/calendar.js
@@ -13,12 +13,6 @@ export default function (eleventyConfig) {
         return cal?.displayName ?? calendarId
     })
 
-    eleventyConfig.addFilter('calendarProjectPath', function (calendarId, calendars) {
-        if (!Array.isArray(calendars)) return null
-        const cal = calendars.find((c) => c.id === calendarId)
-        return cal?.projectPath ?? null
-    })
-
     eleventyConfig.addFilter('calendarWebUrl', function (calendarId, calendars) {
         if (!Array.isArray(calendars)) return '#'
         const cal = calendars.find((c) => c.id === calendarId)

--- a/src/_data/calendarEvents.js
+++ b/src/_data/calendarEvents.js
@@ -115,7 +115,9 @@ export default async function () {
     allInstances.sort(sortByStart)
 
     const oneOff = enrichWithCalendar(allInstances.filter((e) => !e.isRecurring).sort(sortByStart))
-    const recurring = enrichWithCalendar(allInstances.filter((e) => e.isRecurring).sort(sortByStart))
+    const recurring = enrichWithCalendar(
+        allInstances.filter((e) => e.isRecurring).sort(sortByStart)
+    )
 
     return { oneOff, recurring }
 }

--- a/src/_data/calendarEvents.js
+++ b/src/_data/calendarEvents.js
@@ -84,15 +84,13 @@ function getDateRange() {
     return { from, oneYearLater }
 }
 
-function enrichRecurringWithCalendar(events) {
+function enrichWithCalendar(events) {
     return events.map((ev) => {
         const cal = calendars.find((c) => c.id === ev.calendar)
-        const calendarUrl = cal?.webUrl || '#'
         return {
             ...ev,
-            linkUrl: cal?.projectPath || calendarUrl,
-            linkText: cal?.projectPath ? 'View project' : null,
-            calendarUrl,
+            projectImage: cal?.projectImage ?? null,
+            projectPath: cal?.projectPath ?? null,
         }
     })
 }
@@ -116,10 +114,8 @@ export default async function () {
 
     allInstances.sort(sortByStart)
 
-    const oneOff = allInstances.filter((e) => !e.isRecurring).sort(sortByStart)
-    const recurring = enrichRecurringWithCalendar(
-        allInstances.filter((e) => e.isRecurring).sort(sortByStart)
-    )
+    const oneOff = enrichWithCalendar(allInstances.filter((e) => !e.isRecurring).sort(sortByStart))
+    const recurring = enrichWithCalendar(allInstances.filter((e) => e.isRecurring).sort(sortByStart))
 
     return { oneOff, recurring }
 }

--- a/src/_data/calendars.js
+++ b/src/_data/calendars.js
@@ -7,6 +7,7 @@ export default [
         webUrl: 'https://calendar.google.com/calendar/render?cid=2ee6f899173bf6d69fe65d129ec875d2fe2877771d621d81712603b6ac477c5e%40group.calendar.google.com',
         displayName: 'Violet Folk Sings',
         projectPath: '/projects/violet-folk-sings/',
+        projectImage: '/static/images/singingatthehag-square.jpg',
     },
     {
         id: 'paper-plane',
@@ -14,6 +15,7 @@ export default [
         webUrl: 'https://calendar.google.com/calendar/render?cid=5b06a18463f6f333ed3564e67000574cd27300424afbcbe6d38d0153ebb6de8c%40group.calendar.google.com',
         displayName: 'Paper Plane',
         projectPath: '/projects/paper-plane/',
+        projectImage: '/static/images/paper-plane-cozy-square.jpeg',
     },
     {
         id: 'emma',
@@ -21,5 +23,6 @@ export default [
         webUrl: 'https://calendar.google.com/calendar/render?cid=7cb021302629cd50724edd13d6aee91c9602e8554c6b6b355eb2f8f7dbf7e8ab%40group.calendar.google.com',
         displayName: 'Emma Azelborn',
         projectPath: null,
+        projectImage: null,
     },
 ]

--- a/src/_layouts/includes/event-item-image.njk
+++ b/src/_layouts/includes/event-item-image.njk
@@ -1,0 +1,11 @@
+{% if event.projectImage %}
+    {% if event.projectPath %}
+        <a class="event-item-image-link" href="{{ event.projectPath }}" tabindex="-1" aria-hidden="true">
+            <img class="event-item-image" src="{{ event.projectImage }}" alt="">
+        </a>
+    {% else %}
+        <div class="event-item-image-link">
+            <img class="event-item-image" src="{{ event.projectImage }}" alt="">
+        </div>
+    {% endif %}
+{% endif %}

--- a/src/_layouts/includes/events-list.njk
+++ b/src/_layouts/includes/events-list.njk
@@ -1,20 +1,23 @@
 <ul class="event-list event-list--{{ design }}">
     {% for event in calendarEvents %}
-        <li class="event-item event-item--{{ event.calendar }}{% if event.isRecurring %} event-item--recurring{% endif %}">
-            <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
-                {{ event.start | dateEastern("date") }}{% if not event.isFullDay %} · {{ event.start | dateEastern("time") }}{% endif %}{% if event.isRecurring %} · <span class="event-recurring-label">{{ event.recurrenceLabel or 'Recurring' }}</span>{% endif %}
-            </time>
-            <span class="event-title-line"><span class="event-title">{{ event.title }}</span>{% if event.calendar != 'emma' %} {% set projectPath = event.calendar | calendarProjectPath(calendars) %}{% if projectPath %}<a class="event-calendar" href="{{ projectPath }}">{{ event.calendar | calendarDisplayName(calendars) }}</a>{% else %}<span class="event-calendar">{{ event.calendar | calendarDisplayName(calendars) }}</span>{% endif %}{% endif %}</span>
-            {% if event.location %}
-                {% set locationUrl = event.location | locationLinkUrl %}
-                {% if locationUrl %}<a class="event-location" href="{{ locationUrl }}" target="_blank" rel="noopener noreferrer">{{ event.location }}</a>{% else %}<span class="event-location">{{ event.location }}</span>{% endif %}
-            {% endif %}
-            {% if event.description %}
-                <div class="event-description-wrap event-description--truncated">
-                    <div class="event-description">{{ event.description | descriptionToHtml | safe }}</div>
-                </div>
-                <button type="button" class="event-description-toggle" aria-expanded="false" aria-label="Expand description">read more…</button>
-            {% endif %}
+        <li class="event-item event-item--{{ event.calendar }}{% if event.isRecurring %} event-item--recurring{% endif %}{% if event.projectImage %} event-item--has-image{% endif %}">
+            <div class="event-item-content">
+                <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
+                    {{ event.start | dateEastern("date") }}{% if not event.isFullDay %} · {{ event.start | dateEastern("time") }}{% endif %}{% if event.isRecurring %} · <span class="event-recurring-label">{{ event.recurrenceLabel or 'Recurring' }}</span>{% endif %}
+                </time>
+                <span class="event-title-line"><span class="event-title">{{ event.title }}</span>{% if event.calendar != 'emma' %} {% if event.projectPath %}<a class="event-calendar" href="{{ event.projectPath }}">{{ event.calendar | calendarDisplayName(calendars) }}</a>{% else %}<span class="event-calendar">{{ event.calendar | calendarDisplayName(calendars) }}</span>{% endif %}{% endif %}</span>
+                {% if event.location %}
+                    {% set locationUrl = event.location | locationLinkUrl %}
+                    {% if locationUrl %}<a class="event-location" href="{{ locationUrl }}" target="_blank" rel="noopener noreferrer">{{ event.location }}</a>{% else %}<span class="event-location">{{ event.location }}</span>{% endif %}
+                {% endif %}
+                {% if event.description %}
+                    <div class="event-description-wrap event-description--truncated">
+                        <div class="event-description">{{ event.description | descriptionToHtml | safe }}</div>
+                    </div>
+                    <button type="button" class="event-description-toggle" aria-expanded="false" aria-label="Expand description">read more…</button>
+                {% endif %}
+            </div>
+            {% include "includes/event-item-image.njk" %}
         </li>
     {% else %}
         <li class="events-empty">No upcoming events at the moment.</li>

--- a/src/_layouts/includes/events-recurring-list.njk
+++ b/src/_layouts/includes/events-recurring-list.njk
@@ -1,20 +1,23 @@
 <ul class="event-list event-list--cards">
     {% for event in recurringEvents %}
-    <li class="event-item event-item--recurring">
-        <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
-            {{ event.start | dateEastern("date") }}{% if not event.isFullDay %} · {{ event.start | dateEastern("time") }}{% endif %} · <span class="event-recurring-label">{{ event.recurrenceLabel or 'Recurring' }}</span>
-        </time>
-        <span class="event-title-line"><span class="event-title">{{ event.title }}</span>{% if event.calendar != 'emma' %} {% set projectPath = event.calendar | calendarProjectPath(calendars) %}{% if projectPath %}<a class="event-calendar" href="{{ projectPath }}">{{ event.calendar | calendarDisplayName(calendars) }}</a>{% else %}<span class="event-calendar">{{ event.calendar | calendarDisplayName(calendars) }}</span>{% endif %}{% endif %}</span>
-        {% if event.location %}
-            {% set locationUrl = event.location | locationLinkUrl %}
-            {% if locationUrl %}<a class="event-location" href="{{ locationUrl }}" target="_blank" rel="noopener noreferrer">{{ event.location }}</a>{% else %}<span class="event-location">{{ event.location }}</span>{% endif %}
-        {% endif %}
-        {% if event.description %}
-        <div class="event-description-wrap event-description--truncated">
-            <div class="event-description">{{ event.description | descriptionToHtml | safe }}</div>
+    <li class="event-item event-item--recurring{% if event.projectImage %} event-item--has-image{% endif %}">
+        <div class="event-item-content">
+            <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
+                {{ event.start | dateEastern("date") }}{% if not event.isFullDay %} · {{ event.start | dateEastern("time") }}{% endif %} · <span class="event-recurring-label">{{ event.recurrenceLabel or 'Recurring' }}</span>
+            </time>
+            <span class="event-title-line"><span class="event-title">{{ event.title }}</span>{% if event.calendar != 'emma' %} {% if event.projectPath %}<a class="event-calendar" href="{{ event.projectPath }}">{{ event.calendar | calendarDisplayName(calendars) }}</a>{% else %}<span class="event-calendar">{{ event.calendar | calendarDisplayName(calendars) }}</span>{% endif %}{% endif %}</span>
+            {% if event.location %}
+                {% set locationUrl = event.location | locationLinkUrl %}
+                {% if locationUrl %}<a class="event-location" href="{{ locationUrl }}" target="_blank" rel="noopener noreferrer">{{ event.location }}</a>{% else %}<span class="event-location">{{ event.location }}</span>{% endif %}
+            {% endif %}
+            {% if event.description %}
+            <div class="event-description-wrap event-description--truncated">
+                <div class="event-description">{{ event.description | descriptionToHtml | safe }}</div>
+            </div>
+            <button type="button" class="event-description-toggle" aria-expanded="false" aria-label="Expand description">read more…</button>
+            {% endif %}
         </div>
-        <button type="button" class="event-description-toggle" aria-expanded="false" aria-label="Expand description">read more…</button>
-        {% endif %}
+        {% include "includes/event-item-image.njk" %}
     </li>
     {% endfor %}
 </ul>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -282,6 +282,58 @@ a.event-location:hover,
     overflow-wrap: break-word;
 }
 
+.event-list--cards .event-item.event-item--has-image {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0;
+    padding: 0;
+}
+
+.event-list--cards .event-item.event-item--has-image .event-item-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 1.25rem;
+    min-width: 0;
+    overflow-wrap: break-word;
+}
+
+/* Right column inherits card background so there's no gap/bleed behind the image */
+.event-list--cards .event-item.event-item--has-image .event-item-image-link {
+    background-color: var(--color-white);
+    display: flex;
+    align-items: center;
+    padding: 1.25rem 1.25rem 1.25rem 0;
+}
+
+.event-list--cards .event-item.event-item--recurring.event-item--has-image .event-item-image-link {
+    background-color: var(--color-event-recurring-bg);
+}
+
+.event-item-image {
+    display: block;
+    width: 9rem;
+    height: 9rem;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+    .event-list--cards .event-item.event-item--has-image {
+        grid-template-columns: 1fr;
+    }
+
+    .event-list--cards .event-item.event-item--has-image .event-item-image-link {
+        padding: 0 1.25rem 1.25rem;
+        justify-content: center;
+    }
+
+    .event-item-image {
+        width: 100%;
+        height: 12rem;
+    }
+}
+
 .event-list--cards .event-item:last-child {
     border: none;
 }


### PR DESCRIPTION
## Summary

- For events associated with a project (Paper Plane, Violet Folk Sings), the project's image now appears on the right side of the event card, or at the bottom on mobile
- Applies to both one-off events and recurring events
- Image is vertically centered in its column; the column uses the card's background color (white or gray for recurring) so there's no bleed

## What changed

**Data layer**
- Added `projectImage` and `projectPath` to each calendar entry in `calendars.js`
- `enrichWithCalendar()` in `calendarEvents.js` now attaches both fields to all events, removing the need for templates to re-look up calendar metadata; also removed dead `linkUrl`/`linkText`/`calendarUrl` fields that were computed but never used
- Removed the now-unused `calendarProjectPath` filter from `calendar.js`

**Templates**
- Extracted shared image markup into `event-item-image.njk` (included by both `events-list.njk` and `events-recurring-list.njk`)
- Image link uses `tabindex="-1" aria-hidden="true"` since it duplicates the project link already visible in the card title; image `alt` is empty for the same reason

**CSS**
- Cards with images switch from flex to a two-column grid (`1fr auto`)
- Image column: `display: flex; align-items: center` for vertical centering; `background-color` matches the card
- Mobile (<=600px): grid collapses to one column, image moves below content at full width

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
