### PR TITLE
Raise event card collapse threshold from 2 to 6 lines

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -230,7 +230,7 @@ a.event-location:hover,
 
 .event-description-wrap.event-description--truncated {
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 6;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary

- Increases the `-webkit-line-clamp` value on truncated event descriptions from 2 to 6 lines
- Short event descriptions (like Paper Plane gig cards) now display fully without a "read more" button
- Genuinely long descriptions still collapse and show the expand/collapse toggle

## Reviewer notes

No JS changes needed — the existing `hideUnneededExpandButtons` logic already hides the button when content fits within the visible height, so raising the clamp threshold is the only change required.