### PR TITLE
Strip "It's" when sorting song titles

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,7 +10,7 @@ import eventFilters from './eleventy/filters/events.js'
 import lyricsFilter from './eleventy/filters/lyrics.js'
 
 function addCollections(eleventyConfig) {
-    const articlePattern = /^(the|a|an|o)\s+/i
+    const articlePattern = /^(the|a|an|o|it[''']s)\s+/i
     const sortByTitle = (a, b) => {
         const key = (title) => title.replace(articlePattern, '').trim()
         return key(a.data.title).localeCompare(key(b.data.title))


### PR DESCRIPTION
## Summary

- Added `it's` to the article-strip regex used by the songs/songbook collection sort, so "It's Always Been About That" sorts under "Always" with the A titles instead of the I titles — matching how "O Winds that Blow O'er the Sea" already sorts under W.
- Handles straight, curly, and reversed apostrophe variants for robustness.

## Test plan

- [ ] Run `npm run serve` and confirm "It's Always Been About That" appears in the A section of the song list.
- [ ] Confirm "O Winds that Blow O'er the Sea" still sorts under W.

🤖 Generated with [Claude Code](https://claude.com/claude-code)