### PR TITLE
Give 'O Wind' song a clean dash-based URL

### DIFF
--- a/src/songs/o wind (that sings so loud a song).html
+++ b/src/songs/o wind (that sings so loud a song).html
@@ -1,0 +1,25 @@
+---
+permalink: /songs/o wind (that sings so loud a song)/
+eleventyExcludeFromCollections: true
+layout: false
+templateEngineOverride: false
+---
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="refresh" content="0; url=/songs/o-wind-that-sings-so-loud-a-song/" />
+        <link rel="canonical" href="/songs/o-wind-that-sings-so-loud-a-song/" />
+        <title>Redirecting...</title>
+        <script>
+            window.location.href = '/songs/o-wind-that-sings-so-loud-a-song/'
+        </script>
+    </head>
+    <body>
+        <p>
+            I renamed this song. If you are not redirected automatically,
+            <a href="/songs/o-wind-that-sings-so-loud-a-song/">click here</a>.
+        </p>
+    </body>
+</html>

--- a/src/songs/o-wind-that-sings-so-loud-a-song.md
+++ b/src/songs/o-wind-that-sings-so-loud-a-song.md
@@ -2,6 +2,7 @@
 title: O Wind (That Sings so Loud a Song)
 composer: Emma Azelborn
 voiceMemo: the wind that sings so loud a song.mp4
+permalink: /songs/o-wind-that-sings-so-loud-a-song/
 ---
 
 I saw you toss the kites on high


### PR DESCRIPTION
## Summary

- Renamed `src/songs/o wind (that sings so loud a song).md` to `o-wind-that-sings-so-loud-a-song.md` and added an explicit permalink `/songs/o-wind-that-sings-so-loud-a-song/`
- Added a redirect HTML page at the old space-encoded URL (`/songs/o wind (that sings so loud a song)/`) that sends visitors to the new clean URL

## Why

The old filename had spaces and parens, which produced a URL full of `%20` encoding — hard to read and type. Dashes are the convention used everywhere else in the song collection.

## Review notes

- Page title is unchanged (driven by `title` frontmatter, not the filename)
- No project files referenced this song by URL, so no other links needed updating
- Old URL is preserved via the same redirect pattern used for other renamed songs (e.g. `the-north-wind.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)