### PR TITLE
Add SEO basics: sitemap, robots.txt, and per-song meta descriptions

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://use.typekit.net/jps8xwe.css">
     <link rel="stylesheet" href="/static/styles.css">
     <link rel="icon" type="image/png" href="/static/favicon.png">
+    <meta name="description" content="{% if description %}{{ description }}{% else %}Hi, I'm Emma Azelborn. I'm a songwriter, dancer, and musician.{% endif %}">
     <meta property="og:title" content="{% if title %}{{ title }}{% else %}Emma Azelborn{% endif %}">
     <meta property="og:description" content="{% if description %}{{ description }}{% else %}Hi, I'm Emma Azelborn. I'm a songwriter, dancer, and musician.{% endif %}">
     <meta property="og:url" content="https://emmaazelborn.com{{ page.url | default('/') }}">

--- a/src/robots.txt.njk
+++ b/src/robots.txt.njk
@@ -1,0 +1,8 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+---
+User-agent: *
+Allow: /
+
+Sitemap: https://emmaazelborn.com/sitemap.xml

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -1,0 +1,12 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for page in collections.all %}
+  <url>
+    <loc>https://emmaazelborn.com{{ page.url }}</loc>
+  </url>
+{%- endfor %}
+</urlset>

--- a/src/songs/a-different-sea.md
+++ b/src/songs/a-different-sea.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '1499190375'
 composer: Emma Azelborn
+description: "I've been thinking of you lately / but your shore faces a different sea"
 ---
 
 I've been thinking of you lately, my friend

--- a/src/songs/almost-here.md
+++ b/src/songs/almost-here.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '3891230108'
 composer: Emma Azelborn
+description: "your voice in my ear, it is almost like you're here"
 ---
 
 you sang a song to me when I cried on the phone

--- a/src/songs/dragons-of-kilpatrick.md
+++ b/src/songs/dragons-of-kilpatrick.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '4247583798'
+description: "our shining scales protect their sails! / we're the dragons of kilpatrick"
 ---
 
 we are the glinting gilded girls who heard the calling sea

--- a/src/songs/getting-easier.md
+++ b/src/songs/getting-easier.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '1873695983'
 composer: Emma Azelborn
+description: "it's been getting easier to cry"
 ---
 
 it's been getting harder to sing

--- a/src/songs/hen-house-ghost.md
+++ b/src/songs/hen-house-ghost.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '2745536447'
+description: "I am hen house ghost / maybe someday I'll go home"
 ---
 
 Everybody gather round 'cause I can't come to you

--- a/src/songs/her-voice.md
+++ b/src/songs/her-voice.md
@@ -2,6 +2,7 @@
 title: Her Voice
 composer: Emma Azelborn
 voiceMemo: her voice memo.m4a
+description: A song about the women who fought to save California's redwood forests from logging in the early 1900s.
 ---
 
 The ancient trees were falling, the sawmills ever grinding

--- a/src/songs/her-voice.md
+++ b/src/songs/her-voice.md
@@ -2,7 +2,7 @@
 title: Her Voice
 composer: Emma Azelborn
 voiceMemo: her voice memo.m4a
-description: A song about the women who fought to save California's redwood forests from logging in the early 1900s.
+description: 'her voice still echoes through the valley / it weaves through the leaves of the redwood trees'
 ---
 
 The ancient trees were falling, the sawmills ever grinding

--- a/src/songs/holding-a-place-for-you.md
+++ b/src/songs/holding-a-place-for-you.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '3803581021'
+description: "I'm holding a place for you / between the mountains"
 ---
 
 I'm holding a place for you

--- a/src/songs/its-always-been-about-that.md
+++ b/src/songs/its-always-been-about-that.md
@@ -3,6 +3,7 @@ title: It's Always Been About That
 composer: Emma Azelborn
 voiceMemo: its-always-been-about-that-providence.mp4
 voiceMemoCaption: voice memo recorded at the Providence sing on Feb 9 2026
+description: "it's always been about that"
 ---
 
 you say it's all about keeping us safe

--- a/src/songs/join-me-here.md
+++ b/src/songs/join-me-here.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '1601244907'
+description: "this small house is too big for me, won't you join me here"
 ---
 
 this small house is too big for me

--- a/src/songs/legacy-code.md
+++ b/src/songs/legacy-code.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '1536210937'
 composer: Emma Azelborn
+description: "we've gotta go down, down, down / in our legacy, legacy code"
 ---
 
 We've got a problem

--- a/src/songs/magnolia-sun.md
+++ b/src/songs/magnolia-sun.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '1765836546'
 composer: Emma Azelborn
+description: 'she was more than her divining / her magnolia sun still shining'
 ---
 
 I miss her

--- a/src/songs/making-a-promise-to-myself.md
+++ b/src/songs/making-a-promise-to-myself.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '3623366432'
+description: 'I am making a promise to myself'
 ---
 
 I am making a promise to myself

--- a/src/songs/midnight-pizza.md
+++ b/src/songs/midnight-pizza.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '3449868315'
 composer: Emma Azelborn
+description: 'we know what we are wanting / midnight, midnight pizza'
 ---
 
 Late at night we've got the munchies

--- a/src/songs/new-hands-old-strings.md
+++ b/src/songs/new-hands-old-strings.md
@@ -4,6 +4,7 @@ released:
     - project: lucy-goose
       bandcampTrackId: '1422606781'
 composer: Emma Azelborn
+description: 'new hands, old strings / passing their notes with bow and pen'
 ---
 
 New hands, old strings

--- a/src/songs/o-wind-that-sings-so-loud-a-song.md
+++ b/src/songs/o-wind-that-sings-so-loud-a-song.md
@@ -3,6 +3,7 @@ title: O Wind (That Sings so Loud a Song)
 composer: Emma Azelborn
 voiceMemo: the wind that sings so loud a song.mp4
 permalink: /songs/o-wind-that-sings-so-loud-a-song/
+description: 'O wind, O wind, that sings so loud a song'
 ---
 
 I saw you toss the kites on high

--- a/src/songs/o-winds-that-blow-oer-the-sea.md
+++ b/src/songs/o-winds-that-blow-oer-the-sea.md
@@ -3,6 +3,7 @@ title: O Winds That Blow O'er The Sea
 composer: Emma Azelborn
 voiceMemo: oh winds 4 part memo.mp3
 score: /static/scores/o winds that blow oer the sea.pdf
+description: "o winds that blow o'er the sea / tell the story that you bring"
 ---
 
 o winds that blow o'er the sea

--- a/src/songs/poison.md
+++ b/src/songs/poison.md
@@ -4,6 +4,7 @@ released:
     - project: lucy-goose
       bandcampTrackId: '1259949644'
 composer: Emma Azelborn
+description: "I won't let you poison my memories"
 ---
 
 I trusted you and you threw me aside without warning

--- a/src/songs/rainy-morning.md
+++ b/src/songs/rainy-morning.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '2666113275'
 composer: Emma Azelborn
+description: 'we open our eyes to the light of a rainy morning'
 ---
 
 we open our eyes to the light of a rainy morning

--- a/src/songs/ran-right-out-of-breath.md
+++ b/src/songs/ran-right-out-of-breath.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '1048893496'
 composer: Emma Azelborn
+description: 'I would raise my hand and petition the light / till I ran right out of breath'
 ---
 
 on every sunday morning

--- a/src/songs/royal-potatoes.md
+++ b/src/songs/royal-potatoes.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '849002684'
+description: "stay away from the royal potatoes! / they're not for you"
 ---
 
 have you heard the latest news that's been going all around?

--- a/src/songs/sea-creature-of-greenland.md
+++ b/src/songs/sea-creature-of-greenland.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '1768018580'
 composer: Emma Azelborn
+description: 'the sea creature of Greenland / most dreadful and monstrously big'
 ---
 
 Oh the year was 1734

--- a/src/songs/something-growing.md
+++ b/src/songs/something-growing.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '1026509064'
 composer: Emma Azelborn
+description: "I'm in the mood to see something growing"
 ---
 
 I'm going to grow all the good ones here

--- a/src/songs/superstar-limo.md
+++ b/src/songs/superstar-limo.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '700160905'
 composer: Emma Azelborn
+description: 'if you ever wanna glow, you gotta go ride / superstar limo'
 ---
 
 _chorus:_

--- a/src/songs/the-hall-remembers.md
+++ b/src/songs/the-hall-remembers.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '4096891367'
 composer: Emma Azelborn
+description: 'we dance, we dance together / and the hall remembers when we dance'
 ---
 
 In this hall, we dance together

--- a/src/songs/the-north-wind-doth-blow.md
+++ b/src/songs/the-north-wind-doth-blow.md
@@ -2,6 +2,7 @@
 title: The North Wind Doth Blow
 composer: Emma Azelborn
 voiceMemo: the north wind.mp4
+description: 'the north wind doth blow, and we shall have snow'
 ---
 
 **The north wind doth blow,**

--- a/src/songs/this-old-floor.md
+++ b/src/songs/this-old-floor.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '2755393290'
 composer: Emma Azelborn
+description: 'this old floor has held us a hundred years'
 ---
 
 Today, my friends we stand upon these boards so old and worn

--- a/src/songs/toss-the-bones.md
+++ b/src/songs/toss-the-bones.md
@@ -4,6 +4,7 @@ released:
     - project: circle-songs
       bandcampTrackId: '1739601537'
 composer: Emma Azelborn
+description: 'toss the bones high, be steady and small'
 ---
 
 You've been afraid for far too long

--- a/src/songs/trees.md
+++ b/src/songs/trees.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '3139554436'
 composer: Emma Azelborn
+description: 'houses can be made, but trees have to grow'
 ---
 
 you walk down broken tree-lined streets

--- a/src/songs/we-are-here-and-we-are-rising.md
+++ b/src/songs/we-are-here-and-we-are-rising.md
@@ -6,6 +6,7 @@ released:
 youtube: https://youtu.be/Botv3X6XZks
 youtubeCaption: |
     Premiering We Are Here & We Are Rising with Windborne at Flurry Festival 2026
+description: 'we are here and we are rising / we are rising, we hold on'
 ---
 
 we are here and we are **[rising]**

--- a/src/songs/well-burn-away.md
+++ b/src/songs/well-burn-away.md
@@ -4,6 +4,7 @@ released:
     - project: magnolia-sun
       bandcampTrackId: '4276324639'
 composer: Emma Azelborn
+description: "nothing stays the same / we'll rest in the sun and we'll burn away"
 ---
 
 what will we do if the grass doesn't grow

--- a/src/songs/what-the-winds-bring.md
+++ b/src/songs/what-the-winds-bring.md
@@ -2,6 +2,7 @@
 title: What the Winds Bring
 composer: Emma Azelborn
 voiceMemo: what the winds bring.m4a
+description: 'which is the wind that brings the cold? / the North-Wind! the North-Wind!'
 ---
 
 Which is the Wind that brings the cold?

--- a/src/songs/when-we-sing-together.md
+++ b/src/songs/when-we-sing-together.md
@@ -7,6 +7,7 @@ released:
       bandcampTrackId: '3062141228'
 composer: Emma Azelborn
 score: /static/scores/when we sing together.pdf
+description: "when we sing together it's like we were never alone"
 ---
 
 my friends we have traveled far to gather here today

--- a/src/songs/who-has-seen-the-wind.md
+++ b/src/songs/who-has-seen-the-wind.md
@@ -4,6 +4,7 @@ composer: Emma Azelborn
 released:
     - project: circle-songs-vol-ii
       bandcampTrackId: '150032415'
+description: 'who has seen the wind? / neither you nor I'
 ---
 
 Who has seen the wind?

--- a/src/songs/winds-gonna-blow.md
+++ b/src/songs/winds-gonna-blow.md
@@ -2,6 +2,7 @@
 title: Wind's Gonna Blow
 composer: Emma Azelborn
 voiceMemo: winds gonna blow memo.m4a
+description: "gonna keep on walking and the wind's gonna blow"
 ---
 
 gonna keep on **[walking]**

--- a/tests/seo.spec.js
+++ b/tests/seo.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { glob } from 'glob'
 
 const DIST = resolve('dist')
 
@@ -29,11 +30,24 @@ test('sitemap.xml lists posts, songs, and projects with absolute URLs', async ()
 test('pages with a description set a meta description tag, others fall back to the site default', async () => {
     const herVoice = readFileSync(resolve(DIST, 'songs/her-voice/index.html'), 'utf8')
     expect(herVoice).toContain(
-        '<meta name="description" content="A song about the women who fought to save California&#39;s redwood forests from logging in the early 1900s.">'
+        '<meta name="description" content="her voice still echoes through the valley / it weaves through the leaves of the redwood trees">'
     )
 
     const home = readFileSync(resolve(DIST, 'index.html'), 'utf8')
     expect(home).toContain(
         '<meta name="description" content="Hi, I\'m Emma Azelborn. I\'m a songwriter, dancer, and musician.">'
     )
+})
+
+test('every song page sets a lyric-based meta description', async () => {
+    const songFiles = await glob('songs/*/index.html', { cwd: DIST })
+
+    expect(songFiles.length).toBeGreaterThan(0)
+    for (const file of songFiles) {
+        const html = readFileSync(resolve(DIST, file), 'utf8')
+        if (html.includes('Redirecting...')) continue
+        expect(html, `${file} should have a meta description`).toMatch(
+            /<meta name="description" content="[^"]+">/
+        )
+    }
 })

--- a/tests/seo.spec.js
+++ b/tests/seo.spec.js
@@ -39,15 +39,18 @@ test('pages with a description set a meta description tag, others fall back to t
     )
 })
 
-test('every song page sets a lyric-based meta description', async () => {
+test('every song page sets a lyric-based meta description, not the site default', async () => {
     const songFiles = await glob('songs/*/index.html', { cwd: DIST })
+    const genericDescription = "Hi, I'm Emma Azelborn. I'm a songwriter, dancer, and musician."
 
     expect(songFiles.length).toBeGreaterThan(0)
     for (const file of songFiles) {
         const html = readFileSync(resolve(DIST, file), 'utf8')
         if (html.includes('Redirecting...')) continue
-        expect(html, `${file} should have a meta description`).toMatch(
-            /<meta name="description" content="[^"]+">/
+        const match = html.match(/<meta name="description" content="([^"]+)">/)
+        expect(match, `${file} should have a meta description`).not.toBeNull()
+        expect(match[1], `${file} should not use the generic site description`).not.toBe(
+            genericDescription
         )
     }
 })

--- a/tests/seo.spec.js
+++ b/tests/seo.spec.js
@@ -25,3 +25,15 @@ test('sitemap.xml lists posts, songs, and projects with absolute URLs', async ()
     expect(urls.some((url) => url.includes('/songs/'))).toBe(true)
     expect(urls.some((url) => url.includes('/projects/'))).toBe(true)
 })
+
+test('pages with a description set a meta description tag, others fall back to the site default', async () => {
+    const herVoice = readFileSync(resolve(DIST, 'songs/her-voice/index.html'), 'utf8')
+    expect(herVoice).toContain(
+        '<meta name="description" content="A song about the women who fought to save California&#39;s redwood forests from logging in the early 1900s.">'
+    )
+
+    const home = readFileSync(resolve(DIST, 'index.html'), 'utf8')
+    expect(home).toContain(
+        '<meta name="description" content="Hi, I\'m Emma Azelborn. I\'m a songwriter, dancer, and musician.">'
+    )
+})

--- a/tests/seo.spec.js
+++ b/tests/seo.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const DIST = resolve('dist')
+
+test('robots.txt is served at site root and references the sitemap', async () => {
+    const robots = readFileSync(resolve(DIST, 'robots.txt'), 'utf8')
+    expect(robots).toContain('User-agent: *')
+    expect(robots).toContain('Allow: /')
+    expect(robots).toContain('Sitemap: https://emmaazelborn.com/sitemap.xml')
+})
+
+test('sitemap.xml lists posts, songs, and projects with absolute URLs', async () => {
+    const sitemap = readFileSync(resolve(DIST, 'sitemap.xml'), 'utf8')
+    expect(sitemap).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+
+    const urls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1])
+    expect(urls.length).toBeGreaterThan(0)
+    for (const url of urls) {
+        expect(url).toMatch(/^https:\/\/emmaazelborn\.com\//)
+    }
+
+    expect(urls.some((url) => url.includes('/p/'))).toBe(true)
+    expect(urls.some((url) => url.includes('/songs/'))).toBe(true)
+    expect(urls.some((url) => url.includes('/projects/'))).toBe(true)
+})


### PR DESCRIPTION
## Summary
- Adds `sitemap.xml` (auto-generated from `collections.all`) and `robots.txt` so search engines can discover every page, including songs not linked from a single nav.
- Adds a real `<meta name="description">` tag to `base.njk`, reusing the existing `description` frontmatter already used for Open Graph tags.
- Sets a `description` on every song's frontmatter -- a quoted lyric line (chorus/refrain where one exists) instead of a paraphrase, so search snippets and link-preview popups (Slack, Discord, iMessage, etc.) surface the actual lyric instead of the generic site bio.
- Adds `tests/seo.spec.js` covering robots.txt content, sitemap structure/coverage, and per-page meta descriptions -- including a regression check that a song missing its `description` frontmatter doesn't silently fall back to the generic site description and pass anyway.

## Test plan
- [x] `npm run build` succeeds and produces `dist/robots.txt` and `dist/sitemap.xml` with all pages
- [x] `npx playwright test` -- all 10 tests pass (smoke, links, seo)
- [x] Manually verified the new seo test fails when a song's `description` frontmatter is removed, and passes once restored
- [x] `npm run lint && npm run format:check` pass

Generated with Claude Code
