### PR TITLE
Update blog post image caption to include artwork title in italics

### DIFF
--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -4,7 +4,7 @@
     {% if image %}
         <img class="post-image" src="{{ image }}" alt="{{ title }}">
         {% if imageCredit %}
-            <p class="post-image-credit">{% if imageCreditUrl %}<a href="{{ imageCreditUrl }}">{{ imageCredit }}</a>{% else %}{{ imageCredit }}{% endif %}</p>
+            <p class="post-image-credit">{% if imageCreditUrl %}<a href="{{ imageCreditUrl }}">{{ imageCredit | markdownInline | safe }}</a>{% else %}{{ imageCredit | markdownInline | safe }}{% endif %}</p>
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/src/writing/women-queer-folk-songs.md
+++ b/src/writing/women-queer-folk-songs.md
@@ -2,7 +2,7 @@
 title: Trad Songs Centering Women & Queerness
 date: 2026-07-08
 image: /static/images/audrey-sketch-by-angela.avif
-imageCredit: Angela DeCarlis
+imageCredit: _Audrey Jaber_ by Angela DeCarlis
 imageCreditUrl: https://www.angeladecarlis.com/
 description: A spreadsheet of almost 100 traditional song recommendations centering women and queerness
 ---


### PR DESCRIPTION
Renders imageCredit as inline markdown so the caption can include
formatting like the italicized piece title, e.g. "_Audrey Jaber_ by
Angela DeCarlis".