### PR TITLE
Add VSCode format-on-save settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "davidanson.vscode-markdownlint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "[markdown]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "files.trimTrailingWhitespace": false
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `.vscode/settings.json` to format on save with Prettier, auto-trim trailing whitespace, and ensure a final newline — fixes the most common cause of local lint failures when manually creating new pages.
- Markdown files are excluded from VSCode's blanket trailing-whitespace trim, since some song/project `credits` blocks rely on trailing double-spaces as intentional markdown hard-breaks (e.g. `src/projects/magnolia-sun.md`). Prettier itself already leaves these lines untouched (verified via `prettier --write`, no diff), so format-on-save won't break that rendering.
- Adds `.vscode/extensions.json` recommending the Prettier, ESLint, and markdownlint extensions, since format-on-save is a no-op without them installed.

No lint rule changes — `.eslintrc`, `.markdownlint*`, and `.prettierrc` are untouched.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Confirmed `prettier --write` produces no diff on `src/projects/magnolia-sun.md` (hard-break double-spaces preserved)
- [ ] Open VSCode, install recommended extensions, save a file with trailing whitespace / no final newline, confirm auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)