### PR TITLE
CI: unpin Node, bump actions, cache Playwright browser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Use Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v5
               with:
-                  node-version: 20.7.0
+                  node-version: '20.x'
                   cache: 'npm'
 
             - name: Install dependencies
@@ -42,8 +42,26 @@ jobs:
             - name: Build 11ty
               run: npm run build
 
+            # Chromium is ~112 MiB; cache it so we only download on version bumps.
+            - name: Get Playwright version
+              id: playwright-version
+              run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browser
+              id: playwright-cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
             - name: Install Playwright browser
+              if: steps.playwright-cache.outputs.cache-hit != 'true'
               run: npx playwright install --with-deps chromium
+
+            # Cached browsers restore the binary but not the apt system deps.
+            - name: Install Playwright system dependencies
+              if: steps.playwright-cache.outputs.cache-hit == 'true'
+              run: npx playwright install-deps chromium
 
             - name: Run smoke tests
               run: npm run test:nobuild
@@ -79,4 +97,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
         "format": "prettier --write .",
         "format:check": "prettier --check ."
     },
+    "engines": {
+        "node": ">=20.9"
+    },
     "author": "",
     "license": "ISC",
     "description": "",


### PR DESCRIPTION
Three infra fixes from reviewing a recent build log. The run was fully green — these are hardening, not bug fixes.

## P1 — Node 20.7.0 was below what the toolchain requires

The workflow pinned `node-version: 20.7.0`, but ESLint 9 and 11 of its dependencies require `^20.9.0`. Every `npm ci` emitted a wall of `EBADENGINE` warnings; it worked only because npm treats engine mismatches as warnings rather than errors. The next eslint release that actually uses a 20.9+ API would have broken CI with a confusing stack trace instead of a clear version error.

Moved to `20.x` and added `"engines": { "node": ">=20.9" }` so local and CI agree. An exact patch pin also meant never picking up runtime security patches.

## P2 — Playwright browser download was ~30s of every run

`npx playwright install` re-downloaded ffmpeg plus 112 MiB of Chrome Headless Shell on every run — the largest single step in a ~90s build, larger than checkout, install, build and tests combined. It also ran on the daily 12:00 UTC cron, so ~365 needless downloads a year.

Now cached at `~/.cache/ms-playwright`, keyed on the Playwright version resolved from `package-lock.json`, so a dependency bump invalidates the cache automatically. A cache hit restores the browser binary but *not* the apt system dependencies, so those install separately via `playwright install-deps` on the hit path.

## P3 — Actions a major version behind, on deprecated Node 20

Both the build and deploy logs ended with the same warning: `checkout@v4`, `setup-node@v3` and `deploy-pages@v4` target Node 20 and are being force-run on Node 24. Currently a warning; a hard failure once GitHub drops the shim. Bumped all three to v5.

## Verification

- `npm run lint && npm run format:check` — clean
- `npm run build` — 56 files written, 428 images optimized
- `npm run test:nobuild` — 10/10 Playwright tests passed
- Version-extraction command verified locally (resolves to `1.59.1`)
- `package-lock.json` unchanged

The cache path itself can only be proven by CI — expect a miss on this first run, then hits after.

## Not included

`npm audit` reports 14 vulnerabilities (1 critical). I looked at each: all are build-time-only dependencies (`liquidjs`, `markdownlint-cli`, `js-yaml`, `glob`, `ws`) that never reach a visitor's browser, since the output is static HTML. Worth clearing, but `npm audit fix --force` would move `liquidjs` across a major version and break Eleventy templates. That needs an Eleventy bump tested against the real templates — separate PR.

Also worth a follow-up: CLAUDE.md still says "No test suite", which is stale now that there are 10 Playwright smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
