### PR TITLE
CI: test on Node 22.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '20.x'
+                  node-version: '22.x'
                   cache: 'npm'
 
             - name: Install dependencies


### PR DESCRIPTION
Follow-up to #35, now merged. Rebased onto `main` — this is a standalone one-line change, no longer stacked.

Node 20 entered maintenance in late 2026 and stops receiving security patches in April 2026. #35 moved CI off the exact `20.7.0` pin; this moves it onto active LTS so the runtime stays supported.

One-line change: `node-version: '20.x'` → `'22.x'`.

## Why the engines floor stays at >=20.9

I checked whether anything in the dependency tree actually requires Node 22, and nothing does — the only hits were loose `>=16` style ranges. So `"engines": { "node": ">=20.9" }` from #35 is left alone: it states the real minimum, and raising it to `>=22` would falsely reject a working Node 20.9 install for no benefit.

Testing on 22 while permitting 20.9 is the deliberate arrangement. CI exercises the version we intend to ship on; the floor describes what the project genuinely needs.

## Verification

**CI passes on Node 22.x.** This resolves a caveat from the original description: I could only verify locally on Node 24, since this machine has no Node 22 and I did not want to install a version manager for a one-line change. The green build here is the direct evidence that was missing.

## Note on the earlier conflict

This branch briefly showed as conflicting after #35 merged. Cause: #35 was squash-merged, so its commit on `main` was a different SHA carrying identical content to the copy in this branch's history. Git saw both sides touching the same workflow lines and could not tell they were the same change.

Resolved by rebuilding the branch as a single commit on current `main`, so the diff is now exactly the one line it should always have been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
