### PR TITLE
Fix oversized gap between song lyric stanzas

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -702,15 +702,8 @@ body {
     margin-top: 0.5rem;
 }
 
-.song-lyrics .stanza {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-}
-
 .song-lyrics .stanza-empty {
-    min-height: calc(1 * var(--line-height-base-rem));
-    padding-top: 0;
-    padding-bottom: 0;
+    min-height: var(--line-height-base-rem);
 }
 
 .song-lyrics .stanza p {


### PR DESCRIPTION
## Summary
- Song lyric pages had an oversized gap between stanzas: each `.stanza` had `1rem` top+bottom padding, and the blank-line divider (`.stanza-empty`) additionally added a full line-height (`3.6rem`), stacking to nearly `5.6rem` between stanzas instead of a normal single blank-line gap.
- Removed the redundant stanza padding so the blank-line divider alone defines stanza spacing.

## Test plan
- [x] `npm run lint` and `npm run format:check` pass
- [x] Verified in browser preview at mobile (375px), tablet (768px), and desktop widths on multiple song pages (including one with bold repeated lines and an unreleased-song caption) — spacing is even and consistent at all sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)