### PR TITLE
Add timeouts and retries to prevent long CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@v5
 
@@ -57,11 +58,18 @@ jobs:
             - name: Install Playwright browser
               if: steps.playwright-cache.outputs.cache-hit != 'true'
               run: npx playwright install --with-deps chromium
+              timeout-minutes: 5
 
             # Cached browsers restore the binary but not the apt system deps.
+            # Retries + a short per-attempt timeout guard against slow/flaky
+            # apt mirrors turning this into a multi-minute hang.
             - name: Install Playwright system dependencies
               if: steps.playwright-cache.outputs.cache-hit == 'true'
-              run: npx playwright install-deps chromium
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 3
+                  max_attempts: 3
+                  command: npx playwright install-deps chromium
 
             - name: Run smoke tests
               run: npm run test:nobuild


### PR DESCRIPTION
## Summary
- A recent CI build took ~9 minutes longer than normal (see attached logs from the affected run). The delay was entirely in the "Install Playwright system dependencies" step — `npx playwright install-deps chromium` fetched 21.1 MB of font packages at 39.6 kB/s, versus the usual ~8 MB/s, due to a slow/degraded Ubuntu apt mirror.
- This step runs on every cache-hit build (Playwright's browser-binary cache doesn't include the OS-level apt deps), so the job was exposed to this kind of mirror flakiness on nearly every run.
- Added a job-level 15-minute timeout as a backstop, a 5-minute timeout on the full browser install step, and wrapped the system-deps install in `nick-fields/retry@v3` (3 attempts, 3-minute timeout per attempt) so a slow mirror fails fast and retries instead of silently hanging the build.

## Test plan
- [x] `npm run lint` passes
- [x] `npx prettier --check .github/workflows/build.yml` passes
- [ ] Confirm the next CI run picks up the new retry/timeout behavior without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)