### PR TITLE
Fix multiline bold lyrics rendering

### DIFF
--- a/eleventy/filters/lyrics.js
+++ b/eleventy/filters/lyrics.js
@@ -1,4 +1,42 @@
 /**
+ * Splits a paragraph's inner HTML into per-line strings, keeping inline tags
+ * (e.g. <strong>, <em>) that span multiple lines balanced on every resulting
+ * line. This lets markdown like "**line one\nline two**" bold both lines
+ * instead of leaving an unclosed <strong> orphaned across the split.
+ */
+function splitLinesKeepingTagsBalanced(content) {
+    const rawLines = content.split(/<br\s*\/?>(?:\s*)?|\n/)
+    const openTags = []
+    const lines = []
+
+    for (const rawLine of rawLines) {
+        const prefix = openTags.map((tag) => `<${tag}>`).join('')
+        let line = prefix + rawLine
+
+        const tagRegex = /<(\/?)(\w+)[^>]*>/g
+        let match
+        while ((match = tagRegex.exec(rawLine)) !== null) {
+            const [, isClosing, tagName] = match
+            if (isClosing) {
+                const idx = openTags.lastIndexOf(tagName)
+                if (idx !== -1) openTags.splice(idx, 1)
+            } else {
+                openTags.push(tagName)
+            }
+        }
+
+        line += openTags
+            .slice()
+            .reverse()
+            .map((tag) => `</${tag}>`)
+            .join('')
+        lines.push(line.trim())
+    }
+
+    return lines.filter((line) => line.length > 0)
+}
+
+/**
  * Lyrics filter: converts markdown-rendered HTML into stanza divs with empty-line spacing preserved.
  */
 function stanzaHtmlToDivs(lyricsHtml) {
@@ -33,10 +71,7 @@ function stanzasFromHtml(normalized) {
             if (prevPara && prevPara.type === 'content') {
                 result += '<div class="stanza stanza-empty"></div>'
             }
-            const lines = para.content
-                .split(/<br\s*\/?>(?:\s*)?|\n/)
-                .map((line) => line.trim())
-                .filter((line) => line.length > 0)
+            const lines = splitLinesKeepingTagsBalanced(para.content)
             if (lines.length > 0) {
                 result +=
                     '<div class="stanza">' +

--- a/src/songs/along-the-boston-harbor.md
+++ b/src/songs/along-the-boston-harbor.md
@@ -37,10 +37,10 @@ _ending:_
 We saw Long Wharf, the longest wharf
 
 _chorus:_
-**Along the Boston Harbor**
-**There's boats and ships galore**
-**And we say hi and pass them by**
-**On our way to the North Shore**
+**Along the Boston Harbor
+There's boats and ships galore
+And we say hi and pass them by
+On our way to the North Shore**
 
 We saw...
 Commercial Wharf with the counting house!
@@ -54,8 +54,8 @@ We saw...
 Lewis Wharf with the granite stores!
 **Lewis Wharf with the granite stores!**
 
-**And Commercial Wharf with the counting house**
-**And Long Wharf, the longest wharf!!**
+**And Commercial Wharf with the counting house
+And Long Wharf, the longest wharf!!**
 
 _chorus_
 
@@ -63,9 +63,9 @@ We saw...
 Sargents Wharf with the cold storage!
 **Sargents Wharf with the cold storage!**
 
-**And Lewis Wharf with the granite stores**
-**And Commercial Wharf with the counting house**
-**And Long Wharf, the longest wharf!!**
+**And Lewis Wharf with the granite stores
+And Commercial Wharf with the counting house
+And Long Wharf, the longest wharf!!**
 
 _chorus_
 
@@ -73,10 +73,10 @@ We saw...
 Union Wharf with the steamships!
 **Union Wharf with the steamships!**
 
-**And Sargents Wharf with the cold storage**
-**And Lewis Wharf with the granite stores**
-**And Commercial Wharf with the counting house**
-**And Long Wharf, the longest wharf!!**
+**And Sargents Wharf with the cold storage
+And Lewis Wharf with the granite stores
+And Commercial Wharf with the counting house
+And Long Wharf, the longest wharf!!**
 
 _chorus_
 
@@ -84,11 +84,11 @@ We saw...
 Lincoln Wharf with the power plant!
 **Lincoln Wharf with the power plant!**
 
-**And Union Wharf with the steamships**
-**And Sargents Wharf with the cold storage**
-**And Lewis Wharf with the granite stores**
-**And Commercial Wharf with the counting house**
-**And Long Wharf, the longest wharf!!**
+**And Union Wharf with the steamships
+And Sargents Wharf with the cold storage
+And Lewis Wharf with the granite stores
+And Commercial Wharf with the counting house
+And Long Wharf, the longest wharf!!**
 
 _chorus_
 
@@ -96,12 +96,12 @@ We saw...
 Battery Wharf with the sea wall!
 **Battery Wharf with the sea wall!**
 
-**And Lincoln Wharf with the power plant**
-**And Union Wharf with the steamships**
-**And Sargents Wharf with the cold storage**
-**And Lewis Wharf with the granite stores**
-**And Commercial Wharf with the counting house**
-**And Long Wharf, the longest wharf!!**
+**And Lincoln Wharf with the power plant
+And Union Wharf with the steamships
+And Sargents Wharf with the cold storage
+And Lewis Wharf with the granite stores
+And Commercial Wharf with the counting house
+And Long Wharf, the longest wharf!!**
 
 _chorus (x2)_
 

--- a/src/songs/its-always-been-about-that.md
+++ b/src/songs/its-always-been-about-that.md
@@ -7,11 +7,11 @@ description: "it's always been about that"
 ---
 
 you say it's all about keeping us safe
-**no, it's not about keeping us safe**
-**no, no it's never been, never been about that**
+**no, it's not about keeping us safe
+no, no it's never been, never been about that**
 you know it's all about keeping us scared
-**yeah, it's all about keeping us scared**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about keeping us scared
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about self defense /
 you know it's all about shooting first
@@ -33,64 +33,64 @@ keeping us safe / keeping us scared
 ---
 
 you say it's all about keeping us safe
-**no, it's not about keeping us safe**
-**no, no it's never been, never been about that**
+**no, it's not about keeping us safe
+no, no it's never been, never been about that**
 you know it's all about keeping us scared
-**yeah, it's all about keeping us scared**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about keeping us scared
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about self defense
-**no, it's not about self defense**
-**no, no it's never been, never been about that**
+**no, it's not about self defense
+no, no it's never been, never been about that**
 you know it's all about shooting first
-**yeah, it's all about shooting first**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about shooting first
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about terrorists
-**no, it's not about terrorists**
-**no, no it's never been, never been about that**
+**no, it's not about terrorists
+no, no it's never been, never been about that**
 you know it's all about gas and guns
-**yeah, it's all about gas and guns**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about gas and guns
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about protecting jobs
-**no, it's not about protecting jobs**
-**no, no it's never been, never been about that**
+**no, it's not about protecting jobs
+no, no it's never been, never been about that**
 you know it's all about corporate greed
-**yeah, it's all about corporate greed**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about corporate greed
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about the average joe
-**no, it's not about the average joe**
-**no, no it's never been, never been about that**
+**no, it's not about the average joe
+no, no it's never been, never been about that**
 you know it's all about billionaires
-**yeah, it's all about billionaires**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about billionaires
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about family values
-**no, it's not about family values**
-**no, no it's never been, never been about that**
+**no, it's not about family values
+no, no it's never been, never been about that**
 you know it's all about fitting the mold
-**yeah, it's all about fitting the mold**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about fitting the mold
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about the word of god
-**no, it's not about the word of god**
-**no, no it's never been, never been about that**
+**no, it's not about the word of god
+no, no it's never been, never been about that**
 you know it's all about selfish lies
-**yeah, it's all about selfish lies**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about selfish lies
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about fighting crime
-**no, it's not about fighting crime**
-**no, no it's never been, never been about that**
+**no, it's not about fighting crime
+no, no it's never been, never been about that**
 you know it's all about racist hate
-**yeah, it's all about racist hate**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about racist hate
+yeah, yeah, it's always been, always been about that**
 
 you say it's all about keeping us safe
-**no, it's not about keeping us safe**
-**no, no it's never been, never been about that**
+**no, it's not about keeping us safe
+no, no it's never been, never been about that**
 you know it's all about keeping us scared
-**yeah, it's all about keeping us scared**
-**yeah, yeah, it's always been, always been about that**
+**yeah, it's all about keeping us scared
+yeah, yeah, it's always been, always been about that**

--- a/src/songs/making-a-promise-to-myself.md
+++ b/src/songs/making-a-promise-to-myself.md
@@ -27,26 +27,26 @@ I am making a promise to myself
 ---
 
 I am making a promise to myself
-**I am making a promise to myself**
-**'cause I respect myself as much as anyone else**
-**I am making a promise to myself**
+**I am making a promise to myself
+'cause I respect myself as much as anyone else
+I am making a promise to myself**
 
 I will stand by this promise to myself
-**I will stand by this promise to myself**
-**'cause I respect myself as much as anyone else**
-**I will stand by this promise to myself**
+**I will stand by this promise to myself
+'cause I respect myself as much as anyone else
+I will stand by this promise to myself**
 
 I am trusting this promise to myself
-**I am trusting this promise to myself**
-**'cause I respect myself as much as anyone else**
-**I am trusting this promise to myself**
+**I am trusting this promise to myself
+'cause I respect myself as much as anyone else
+I am trusting this promise to myself**
 
 I am living this promise to myself
-**I am living this promise to myself**
-**'cause I respect myself as much as anyone else**
-**I am living this promise to myself**
+**I am living this promise to myself
+'cause I respect myself as much as anyone else
+I am living this promise to myself**
 
 I am making a promise to myself
-**I am making a promise to myself**
-**'cause I respect myself as much as anyone else**
-**I am making a promise to myself**
+**I am making a promise to myself
+'cause I respect myself as much as anyone else
+I am making a promise to myself**

--- a/src/songs/o-wind-that-sings-so-loud-a-song.md
+++ b/src/songs/o-wind-that-sings-so-loud-a-song.md
@@ -14,10 +14,10 @@ and all around I heard you pass
 like layered skirts across the grass
 
 _chorus:_
-**O wind, O wind, a-blowing all day long**
-**a-blowing, a-blowing, a-blowing all day long**
-**O wind, O wind, that sings so loud a song,**
-**that sings so loud a song!**
+**O wind, O wind, a-blowing all day long
+a-blowing, a-blowing, a-blowing all day long
+O wind, O wind, that sings so loud a song,
+that sings so loud a song!**
 
 I saw the different things you did
 **the things you did, the things you did**

--- a/src/songs/the-hall-remembers.md
+++ b/src/songs/the-hall-remembers.md
@@ -24,36 +24,36 @@ dance together
 ---
 
 In this hall, we dance together
-**We dance together**
-**We dance, we dance together**
-**And the hall remembers when we dance**
+**We dance together
+We dance, we dance together
+And the hall remembers when we dance**
 
 In this hall, we swing our partners
-**We swing our partners**
-**We swing, we swing our partners**
-**And the hall remembers when we dance**
+**We swing our partners
+We swing, we swing our partners
+And the hall remembers when we dance**
 
 In this hall, we stomp our feet
-**We stomp our feet**
-**We stomp, we stomp our feet**
-**And the hall remembers when we dance**
+**We stomp our feet
+We stomp, we stomp our feet
+And the hall remembers when we dance**
 
 In this hall, we play the fiddle
-**We play the fiddle**
-**We play, we play the fiddle**
-**And the hall remembers when we dance**
+**We play the fiddle
+We play, we play the fiddle
+And the hall remembers when we dance**
 
 In this hall, we call our dances
-**We call our dances**
-**We call, we call our dances**
-**And the hall remembers when we dance**
+**We call our dances
+We call, we call our dances
+And the hall remembers when we dance**
 
 In this hall, we sing the chorus
-**We sing the chorus**
-**We sing, we sing the chorus**
-**And the hall remembers when we dance**
+**We sing the chorus
+We sing, we sing the chorus
+And the hall remembers when we dance**
 
 In this hall, we dance together
-**We dance together**
-**We dance, we dance together**
-**And the hall remembers when we dance**
+**We dance together
+We dance, we dance together
+And the hall remembers when we dance**


### PR DESCRIPTION
## Summary
- Join Me Here's chorus used `**bold text spanning\nmultiple lines**`, but the lyrics filter split paragraphs into per-line `<p>` tags on newlines *before* those lines were bolded, which orphaned the opening/closing `<strong>` tags on the first/last lines only — leaving the middle lines unbolded.
- Fixed `eleventy/filters/lyrics.js` to track open inline tags (`<strong>`, `<em>`, etc.) across the line split and rebalance them on each resulting line, so multiline bold spans render correctly on every line.
- Converted several songs that were using repeated per-line `**bold**\n**bold**` as a workaround back to the more readable block `**bold\nbold**` syntax now that the parser handles it correctly: `along-the-boston-harbor.md`, `its-always-been-about-that.md`, `making-a-promise-to-myself.md`, `o-wind-that-sings-so-loud-a-song.md`, `the-hall-remembers.md`. `join-me-here.md` was already in block form and now renders correctly.

## Test plan
- [x] `npm run build` and confirmed every `<strong>`/`</strong>` (and `<em>`/`</em>`) tag pair is balanced across all built song pages
- [x] Visually verified in browser: Join Me Here, Along the Boston Harbor, It's Always Been About That, The Hall Remembers all render fully bolded lines
- [x] `npm run lint && npm run format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)