### PR TITLE
Fix stale test-suite and architecture docs in CLAUDE.md/README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run serve      # Dev server at http://localhost:8080 (PROD=0, no cache)
-npm run build      # Production build to dist/ (PROD=1, 1d cache)
-npm run lint       # Run JS (eslint) + Markdown (markdownlint) linting
-npm run format     # Auto-format with Prettier
+npm run serve         # Dev server at http://localhost:8080 (PROD=0, no cache)
+npm run build         # Production build to dist/ (PROD=1, 1d cache)
+npm run test          # Build, then run the Playwright test suite against dist/
+npm run test:nobuild  # Run the Playwright test suite against the existing dist/ (skips the rebuild)
+npm run lint          # Run JS (eslint) + Markdown (markdownlint) linting
+npm run format        # Auto-format with Prettier
 ```
 
-No test suite — verify changes by running `serve` and checking the browser.
+Tests live in `tests/` and run against the built site (`dist/`) via a local `http-server`, not the dev server — see `playwright.config.js` for the webServer/port setup. Coverage includes:
+
+- `tests/smoke.spec.js` — key pages (homepage, a song page, a project page, writing index + a post, events page) render without console errors and show expected content
+- `tests/links.spec.js` — every internal `href` in the built HTML resolves to a real file in `dist/`
+- `tests/seo.spec.js` — `robots.txt`/`sitemap.xml` are correct and pages set proper meta descriptions
+
+`npm run test` always rebuilds first, so it reflects your latest changes; use `npm run test:nobuild` only when `dist/` is already current (e.g. re-running after a test-only edit). CI (`.github/workflows/build.yml`) lints, builds, caches the Playwright Chromium binary, installs it (with retries for system deps), and runs `npm run test:nobuild` against that build on every push/PR to `main`.
 
 Always run `npm run lint && npm run format:check` before finalizing any changes. If `format:check` fails, run `npm run format` to auto-fix.
 
@@ -31,7 +39,7 @@ This serves the worktree from a deterministic port derived from the branch name 
 
 ## Architecture
 
-This is an [Eleventy](https://www.11ty.dev/) static site. Source is in `src/`, output goes to `dist/`. Templates use Nunjucks (`.njk`); Markdown also runs through Nunjucks. Layouts and includes are both in `src/_layouts/`.
+This is an [Eleventy](https://www.11ty.dev/) static site. Source is in `src/`, output goes to `dist/`. Templates use Nunjucks (`.njk`). `eleventy.config.js` sets `markdownTemplateEngine: 'njk'`, intending for Markdown files to also run through Nunjucks, but the build currently processes them via Liquid instead (visible in the `npm run build` log, e.g. `(liquid)` next to each `.md` output) — see issue #50. Layouts and includes are both in `src/_layouts/`.
 
 ### Content collections
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,27 @@ The site is built using the following structure:
 
 ```text
 src/
-├── _layouts/          # Nunjucks templates
-│   ├── base.njk      # Base layout with common HTML structure
-│   ├── post.njk      # Layout for blog posts
-│   └── page.njk      # Layout for regular pages
-├── blog/             # Blog posts in Markdown
-├── index.njk         # Homepage template
+├── _data/             # Global data files (site config, calendar feeds/events)
+│   ├── config.yaml    # Site-level config (e.g. homepage highlighted projects)
+│   ├── calendars.js   # Google Calendar feed metadata
+│   └── calendarEvents.js  # Fetches/parses calendar feeds at build time
+├── _layouts/           # Nunjucks templates
+│   ├── base.njk       # Base layout with common HTML structure
+│   ├── post.njk       # Layout for blog posts
+│   ├── page.njk       # Layout for regular pages
+│   ├── project.njk    # Layout for project pages
+│   ├── song.njk       # Layout for song pages
+│   ├── events.njk     # Layout for the events page
+│   └── includes/      # Shared partials
+├── writing/            # Blog posts in Markdown (permalink pattern p/<slug>/)
+├── songs/              # Song pages in Markdown (lyrics as body content)
+├── projects/           # Project pages in Markdown (albums, releases)
+├── static/             # Passed through as-is to dist/static/ (styles, audio, images, scores)
+├── home.njk            # Homepage template
 └── ...other pages
 ```
+
+`eleventy/filters/` (project root, not under `src/`) holds custom Eleventy filters registered in `eleventy.config.js`: `calendar.js` (filter events by calendar ID), `events.js` (date/location formatting), and `lyrics.js` (stanza rendering for song pages).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ The site is built using the following structure:
 
 ```text
 src/
-├── _data/             # Global data files (site config, calendar feeds/events)
-│   ├── config.yaml    # Site-level config (e.g. homepage highlighted projects)
-│   ├── calendars.js   # Google Calendar feed metadata
-│   └── calendarEvents.js  # Fetches/parses calendar feeds at build time
-├── _layouts/           # Nunjucks templates
-│   ├── base.njk       # Base layout with common HTML structure
-│   ├── post.njk       # Layout for blog posts
-│   ├── page.njk       # Layout for regular pages
-│   ├── project.njk    # Layout for project pages
-│   ├── song.njk       # Layout for song pages
-│   ├── events.njk     # Layout for the events page
-│   └── includes/      # Shared partials
-├── writing/            # Blog posts in Markdown (permalink pattern p/<slug>/)
-├── songs/              # Song pages in Markdown (lyrics as body content)
-├── projects/           # Project pages in Markdown (albums, releases)
-├── static/             # Passed through as-is to dist/static/ (styles, audio, images, scores)
-├── home.njk            # Homepage template
+├── _data/                  # Global data files (site config, calendar feeds/events)
+│   ├── config.yaml         # Site-level config (e.g. homepage highlighted projects)
+│   ├── calendars.js        # Google Calendar feed metadata
+│   └── calendarEvents.js   # Fetches/parses calendar feeds at build time
+├── _layouts/               # Nunjucks templates
+│   ├── base.njk            # Base layout with common HTML structure
+│   ├── post.njk            # Layout for blog posts
+│   ├── page.njk            # Layout for regular pages
+│   ├── project.njk         # Layout for project pages
+│   ├── song.njk            # Layout for song pages
+│   ├── events.njk          # Layout for the events page
+│   └── includes/           # Shared partials
+├── writing/                # Blog posts in Markdown (permalink pattern p/<slug>/)
+├── songs/                  # Song pages in Markdown (lyrics as body content)
+├── projects/               # Project pages in Markdown (albums, releases)
+├── static/                 # Passed through as-is to dist/static/ (styles, audio, images, scores)
+├── home.njk                # Homepage template
 └── ...other pages
 ```
 


### PR DESCRIPTION
## Summary

- CLAUDE.md claimed "No test suite — verify changes by running `serve` and checking the browser." That's stale: there's a Playwright suite in `tests/` (`smoke.spec.js`, `links.spec.js`, `seo.spec.js`) that runs against the built site. Documented `npm run test` (builds then tests) and `npm run test:nobuild` (tests only, verified both scripts exist in `package.json`), what each spec file covers, and what CI (`.github/workflows/build.yml`) actually does (lint, build, cache/install Playwright's Chromium with retries, run `test:nobuild`).
- While investigating, found the CLAUDE.md architecture line "Markdown also runs through Nunjucks" doesn't match what `npm run build` actually does in this worktree — the build log shows `.md` files rendering via `(liquid)` even though `eleventy.config.js` sets `markdownTemplateEngine: 'njk'`. Corrected the prose to describe this observed behavior and pointed at #50 rather than leaving a false claim in place.
- README.md's architecture tree referenced `src/blog/` and `src/index.njk`, neither of which exist (actual paths are `src/writing/` and `src/home.njk`). Fixed those and added the previously-missing `src/_data/`, `src/songs/`, `src/projects/`, and `eleventy/filters/` entries with brief descriptions based on what's actually in each.

Fixes #51

## Out of scope (intentionally)

This PR does not touch the underlying template-engine bug (#50) or document the slug-redirect pattern (#56) — both are being handled in separate worktrees/PRs to avoid conflicting edits. The template-engine wording change here only corrects CLAUDE.md's prose to match current (unfixed) reality; it doesn't change any code.

## Test plan

- [x] `npm install` (fresh worktree, no `node_modules`)
- [x] `npm run build` — succeeds, doc-only change
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
