### PR TITLE
Consolidate duplicated HTML-escape and date-format helpers

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -9,6 +9,7 @@ import markdownItAnchor from 'markdown-it-anchor'
 import calendarFilters from './eleventy/filters/calendar.js'
 import eventFilters from './eleventy/filters/events.js'
 import lyricsFilter from './eleventy/filters/lyrics.js'
+import { escapeHtml } from './eleventy/filters/utils.js'
 
 function addCollections(eleventyConfig) {
     const articlePattern = /^(the|a|an|o|it[''']s)\s+/i
@@ -79,12 +80,7 @@ export default async function (eleventyConfig) {
     // Escape and normalize caption text (HTML-escape + newlines to <br>)
     eleventyConfig.addFilter('captionSafe', (text) => {
         if (!text || typeof text !== 'string') return ''
-        return text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/\n/g, '<br>')
+        return escapeHtml(text).replace(/\n/g, '<br>')
     })
 
     // Add YAML as an acceptable data file format

--- a/eleventy/filters/events.js
+++ b/eleventy/filters/events.js
@@ -2,7 +2,29 @@
  * Event display filters: location links, description HTML, Eastern-time date formatting.
  */
 
+import { escapeHtml } from './utils.js'
+
 const EASTERN_TZ = 'America/New_York'
+
+// Shared Intl.DateTimeFormat option sets, reused by dateEastern below.
+const DATE_PART_OPTIONS = {
+    timeZone: EASTERN_TZ,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+}
+const TIME_PART_OPTIONS = {
+    timeZone: EASTERN_TZ,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+}
+
+// Constructing an Intl.DateTimeFormat is relatively expensive, so build these
+// once at module scope and reuse them across calls rather than per-call.
+const dateFormatter = new Intl.DateTimeFormat('en-US', DATE_PART_OPTIONS)
+const timeFormatter = new Intl.DateTimeFormat('en-US', TIME_PART_OPTIONS)
 
 const NON_ADDRESS_PATTERNS = [
     /^zoom\b/i,
@@ -38,47 +60,26 @@ export default function (eleventyConfig) {
         if (str == null || str === '') return ''
         const s = String(str).replace(/\r\n/g, '\n').replace(/\r/g, '\n')
         if (/<[a-z][^>]*>/i.test(s)) return s
-        const escaped = s
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-        return escaped.replace(/\n/g, '<br>')
+        return escapeHtml(s).replace(/\n/g, '<br>')
     })
 
+    // Event dates use raw Intl + a fixed Eastern timezone here instead of the
+    // date-fns + @date-fns/utc combo used for content dates (see the `date`
+    // filter in eleventy.config.js). Content dates (posts, projects) are
+    // date-only values with no meaningful timezone, so they're formatted as
+    // UTC to avoid off-by-one-day shifts. Event times are genuinely
+    // timezone-bound — they represent a specific instant that should always
+    // display in Eastern regardless of server/viewer timezone — which is a
+    // different problem best solved with Intl's built-in timeZone support.
     eleventyConfig.addFilter('dateEastern', (date, formatType = 'date') => {
         if (!date) return ''
         const d = new Date(date)
         if (formatType === 'time') {
-            return new Intl.DateTimeFormat('en-US', {
-                timeZone: EASTERN_TZ,
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true,
-            }).format(d)
+            return timeFormatter.format(d)
         }
         if (formatType === 'datetime') {
-            const dateStr = new Intl.DateTimeFormat('en-US', {
-                timeZone: EASTERN_TZ,
-                weekday: 'short',
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-            }).format(d)
-            const timeStr = new Intl.DateTimeFormat('en-US', {
-                timeZone: EASTERN_TZ,
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true,
-            }).format(d)
-            return `${dateStr} at ${timeStr}`
+            return `${dateFormatter.format(d)} at ${timeFormatter.format(d)}`
         }
-        return new Intl.DateTimeFormat('en-US', {
-            timeZone: EASTERN_TZ,
-            weekday: 'short',
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric',
-        }).format(d)
+        return dateFormatter.format(d)
     })
 }

--- a/eleventy/filters/utils.js
+++ b/eleventy/filters/utils.js
@@ -1,0 +1,14 @@
+/**
+ * Shared helpers used across multiple Eleventy filters.
+ */
+
+// Escapes the five HTML-significant characters. Callers that also want to
+// turn newlines into <br> do that themselves afterward, since that's a
+// presentation choice rather than strictly part of escaping.
+export function escapeHtml(str) {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+}


### PR DESCRIPTION
## Summary
- Extracts the HTML-escape chain (`&` `<` `>` `"`) duplicated in `captionSafe` (`eleventy.config.js`) and `descriptionToHtml` (`eleventy/filters/events.js`) into a single shared `escapeHtml()` helper in a new `eleventy/filters/utils.js`. Each caller still applies its own newline-to-`<br>` handling on top, since that's a presentation choice rather than strictly "escaping." The `descriptionToHtml` HTML-passthrough branch (for Google Calendar descriptions that already contain HTML) is preserved exactly as-is.
- Hoists the two `Intl.DateTimeFormat` option sets used by `dateEastern` (weekday/month/day/year, and hour/minute) into module-level constants, and constructs the two formatters once at module scope instead of rebuilding them on every call.
- Adds a short comment explaining why `dateEastern` uses raw `Intl` + a fixed Eastern timezone instead of the `date-fns` + `@date-fns/utc` combo used for content dates elsewhere (event times are genuinely timezone-bound; content dates are date-only).

This is a pure internal refactor — no observable output changes.

Fixes #57

## Verification
- Built `dist/` from `main` and from this branch and confirmed `diff -rq` reports **zero differences** across the entire output tree (all pages, including events pages using `descriptionToHtml`/`dateEastern` and song pages using `captionSafe`).
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run test` (Playwright, 10 tests) — all passing

## Test plan
- [x] `npm run build` succeeds
- [x] `diff -rq` against a `main` build shows no differences
- [x] `npm run lint && npm run format:check` pass
- [x] `npm run test` passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
