### PR TITLE
Fix markdownTemplateEngine/htmlTemplateEngine being silently ignored

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -169,9 +169,11 @@ export const config = {
         // for simplicity
         layouts: '_layouts',
         includes: '_layouts',
-        // Switch Markdown and HTML template engines to Nunjucks
-        // (otherwise, the default is Liquid)
-        htmlTemplateEngine: 'njk',
-        markdownTemplateEngine: 'njk',
     },
+    // Switch Markdown and HTML template engines to Nunjucks (otherwise, the
+    // default is Liquid). These must be top-level keys, not nested under
+    // `dir` — Eleventy only reads `dir` for directory settings and silently
+    // ignores anything else placed inside it.
+    htmlTemplateEngine: 'njk',
+    markdownTemplateEngine: 'njk',
 }


### PR DESCRIPTION
## Summary

Fixes #50.

`htmlTemplateEngine` and `markdownTemplateEngine` were nested inside the `dir` object of the exported `config`, e.g.:

```js
export const config = {
    dir: {
        input: 'src',
        output: 'dist',
        layouts: '_layouts',
        includes: '_layouts',
        htmlTemplateEngine: 'njk',
        markdownTemplateEngine: 'njk',
    },
}
```

Eleventy v3 only reads `dir` for directory settings - it hands `exportedConfigObject.dir` off to a dedicated `Directories` class (`this.directories.setViaConfigObject(...)`) that only understands directory keys (`input`, `output`, `layouts`, `includes`, `data`). Anything else nested inside `dir`, including the engine keys, is silently dropped. `markdownTemplateEngine`/`htmlTemplateEngine` are top-level config properties (see `node_modules/@11ty/eleventy/src/defaultConfig.js`), so they need to be siblings of `dir`, not nested inside it.

The fix moves both keys out to the top level of the `config` object, and rewrites the inline comment so it explains why they can't live inside `dir` (to prevent this regression from recurring).

## Evidence

**Before** (stashed the fix, ran `npm run build`): every markdown-derived output file logs `(liquid)`, e.g.

```
[11ty] Writing ./dist/projects/circle-songs-vol-ii/index.html from ./src/projects/circle-songs-vol-ii.md (liquid)
```

48 files logged `(liquid)`, 0 logged `(njk)`.

**After** (fix applied): every markdown-derived output file logs `(njk)`:

```
[11ty] Writing ./dist/projects/circle-songs-vol-ii/index.html from ./src/projects/circle-songs-vol-ii.md (njk)
```

48 files logged `(njk)`, 0 logged `(liquid)`.

**`{% set %}` probe** (Nunjucks-only tag, unsupported by Liquid): added a scratch file `src/writing/probe-njk-test.md` with body `{% set probe = "abc" %}{{ probe }}`.

- Before fix: fatal build error - `AssertionError: tag "set" not found` (via `TemplateContentRenderError` / `ParseError`), the exact symptom reported in the issue.
- After fix: builds cleanly and renders `<p>abc</p>` in the output HTML.

The scratch probe file was deleted before committing; it is not part of this PR.

`.njk` files (e.g. `src/home.njk`, `src/songs.njk`, `src/events.njk`, `src/writing.njk`) continue to build correctly - they already select the Nunjucks engine by extension, independent of this setting, and are unaffected.

## Test plan

- [x] `npm install`
- [x] `npm run build` - all markdown-derived files log `(njk)`, none log `(liquid)`
- [x] `{% set %}` probe in a scratch `.md` file rendered correctly (then deleted before commit)
- [x] Confirmed `.njk` files unaffected
- [x] `npm run lint` - passes
- [x] `npm run format:check` - passes
- [x] `npm run test` (Playwright, 10 tests) - all pass

Note: doc corrections related to this bug are tracked separately in #51 and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
