### PR TITLE
Quote all Bandcamp IDs to prevent YAML integer coercion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Each collection directory has a `<dir>.yaml` file (e.g. `songs.yaml`) that sets 
 
 Songs are Markdown files with lyrics as body content. Key frontmatter fields:
 
-- `released`: array of `{ project, bandcampTrackId }` — links song to a project for the "Appears in" section and Bandcamp embed. If `project` is omitted but `bandcampTrackId` is present, embeds a standalone track player.
+- `released`: array of `{ project, bandcampTrackId }` — links song to a project for the "Appears in" section and Bandcamp embed. If `project` is omitted but `bandcampTrackId` is present, embeds a standalone track player. **`bandcampTrackId` must always be single-quoted** (e.g. `'849002684'`) — it's an opaque Bandcamp identifier, not a number. Left unquoted, YAML parses it as an integer: leading zeros are silently stripped (pointing at the wrong track), and very large IDs could eventually lose precision as floats. A build-time check in `eleventy.config.js` warns if any `bandcampTrackId` isn't a string.
 - `voiceMemo` / `voiceMemoCaption`: filename in `src/static/audio/` for an audio player (shown only when not released)
 - `youtube` / `youtubeCaption`: YouTube URL or 11-char video ID
 - `score`: path to PDF in `src/static/scores/`
@@ -59,7 +59,7 @@ The `lyrics` Nunjucks filter (`eleventy/filters/lyrics.js`) converts the rendere
 
 Projects link to Bandcamp albums, list track songs, and optionally show upcoming calendar events.
 
-- `bandcampID` + `bandcampUrl`: renders a Bandcamp album embed
+- `bandcampID` + `bandcampUrl`: renders a Bandcamp album embed (both must be present — `src/_layouts/project.njk` gates the embed on `bandcampID and bandcampUrl`). **`bandcampID` must always be single-quoted** (e.g. `'1408015257'`) for the same reason as `bandcampTrackId` above — it's an opaque identifier, not a number, and unquoted values are vulnerable to YAML integer coercion (stripped leading zeros, eventual float precision loss). A build-time check in `eleventy.config.js` warns if any `bandcampID` isn't a string, or if only one of `bandcampID`/`bandcampUrl` is set (the embed would silently fail to render).
 - `songLink`: streaming link (Apple Music, etc.)
 - `songs`: array of `{ title, lyricsUrl }` — tracklist with optional links to song pages
 - `calendarId`: matches a calendar `id` in `src/_data/calendars.js` — pulls live events from that Google Calendar into the project page

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -23,15 +23,60 @@ function addCollections(eleventyConfig) {
             .sort((a, b) => new Date(b.data.date) - new Date(a.data.date))
     )
 
-    eleventyConfig.addCollection('projects', (collection) =>
-        collection
+    eleventyConfig.addCollection('projects', (collection) => {
+        const projects = collection
             .getFilteredByGlob('src/projects/*.md')
             .sort((a, b) => new Date(b.data.date) - new Date(a.data.date))
-    )
+        validateProjectBandcampFields(projects)
+        return projects
+    })
 
-    eleventyConfig.addCollection('songs', (collection) =>
-        collection.getFilteredByGlob('src/songs/*.md').sort(sortByTitle)
-    )
+    eleventyConfig.addCollection('songs', (collection) => {
+        const songs = collection.getFilteredByGlob('src/songs/*.md').sort(sortByTitle)
+        validateSongBandcampFields(songs)
+        return songs
+    })
+}
+
+// Bandcamp IDs are opaque identifiers, not numbers, and must be quoted as
+// strings in YAML frontmatter. An unquoted numeric ID gets parsed as a YAML
+// integer: leading zeros are silently stripped (e.g. 0849002684 becomes
+// 849002684, pointing at the wrong track), and sufficiently large IDs could
+// eventually lose precision as floats. The failure is invisible at build
+// time — the page renders and the iframe loads, it just embeds the wrong
+// track. These checks catch a future unquoted ID as soon as it's added.
+function validateSongBandcampFields(songs) {
+    for (const song of songs) {
+        const released = song.data.released
+        if (!Array.isArray(released)) continue
+        for (const release of released) {
+            const id = release.bandcampTrackId
+            if (id !== undefined && typeof id !== 'string') {
+                console.warn(
+                    `WARNING: ${song.inputPath} has a non-string bandcampTrackId (${id}). ` +
+                        `Quote it in the frontmatter (e.g. '${id}') to avoid YAML integer coercion.`
+                )
+            }
+        }
+    }
+}
+
+function validateProjectBandcampFields(projects) {
+    for (const project of projects) {
+        const { bandcampID, bandcampUrl } = project.data
+        if (bandcampID !== undefined && typeof bandcampID !== 'string') {
+            console.warn(
+                `WARNING: ${project.inputPath} has a non-string bandcampID (${bandcampID}). ` +
+                    `Quote it in the frontmatter (e.g. '${bandcampID}') to avoid YAML integer coercion.`
+            )
+        }
+        if (Boolean(bandcampID) !== Boolean(bandcampUrl)) {
+            console.warn(
+                `WARNING: ${project.inputPath} has only one of bandcampID/bandcampUrl set. ` +
+                    `The Bandcamp embed is gated on both being present, so it will silently not render.`
+            )
+        }
+    }
 }
 
 export default async function (eleventyConfig) {

--- a/src/projects/magnolia-sun.md
+++ b/src/projects/magnolia-sun.md
@@ -5,7 +5,7 @@ image: /static/images/magnolia-sun-album-art.png
 summary: "An introspective mix of original songs blending folk, jazz, and pop"
 description: "During the lonely days of COVID quarantine, I dove into songwriting. What started as an escape turned into a collection of songs that follow the journey from those isolated times through the gradual reopening of the world.
 It’s been incredible to see these songs grow far beyond what I imagined. A huge part of that has been the chance to collaborate with the amazing friends and musicians that brought these songs to life in ways I never could have alone."
-bandcampID: "1983118898"
+bandcampID: '1983118898'
 bandcampUrl: "/album/magnolia-sun"
 songLink: "https://album.link/s/7grSbplzaqUnZo2wsteiXv"
 songs:

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -22,7 +22,11 @@ test('song page renders lyric stanzas and Bandcamp embed when released', async (
     await expect(stanzas.first()).toBeVisible()
     expect(await stanzas.count()).toBeGreaterThan(1)
     await expect(page.locator('.song-projects')).toContainText('Magnolia Sun')
-    await expect(page.locator('iframe[src*="bandcamp.com"]').first()).toBeVisible()
+    const iframe = page.locator('iframe[src*="bandcamp.com"]').first()
+    await expect(iframe).toBeVisible()
+    // Guards against YAML integer coercion of bandcampTrackId (unquoted IDs
+    // lose leading zeros or precision) silently swapping in the wrong track.
+    await expect(iframe).toHaveAttribute('src', /track=1765836546\b/)
     expect(getErrors()).toEqual([])
 })
 
@@ -30,9 +34,11 @@ test('project page renders Bandcamp embed and tracklist', async ({ page }) => {
     const getErrors = trackPageErrors(page)
     await page.goto('/projects/magnolia-sun/')
     await expect(page.locator('h2').first()).toContainText('Magnolia Sun')
-    await expect(
-        page.locator('iframe[src*="bandcamp.com/EmbeddedPlayer/album="]').first()
-    ).toBeVisible()
+    const iframe = page.locator('iframe[src*="bandcamp.com/EmbeddedPlayer/album="]').first()
+    await expect(iframe).toBeVisible()
+    // Guards against YAML integer coercion of bandcampID (unquoted IDs lose
+    // leading zeros or precision) silently swapping in the wrong album.
+    await expect(iframe).toHaveAttribute('src', /album=1983118898\b/)
     const tracks = page.locator('.project-content ol li')
     expect(await tracks.count()).toBeGreaterThan(0)
     await expect(page.locator('.credits')).toBeVisible()

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,9 +1,25 @@
 import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { glob } from 'glob'
+import yaml from 'js-yaml'
+
+const DIST = resolve('dist')
 
 function trackPageErrors(page) {
     const errors = []
     page.on('pageerror', (err) => errors.push(err.message))
     return () => errors
+}
+
+// Parses the YAML frontmatter block (between the leading `---` fences) out of
+// a Markdown source file, matching the delimiter convention used throughout
+// src/songs and src/projects.
+function readFrontmatter(path) {
+    const raw = readFileSync(path, 'utf8')
+    const match = raw.match(/^---\n([\s\S]*?)\n---/)
+    if (!match) return {}
+    return yaml.load(match[1]) || {}
 }
 
 test('homepage loads with highlighted projects', async ({ page }) => {
@@ -43,6 +59,51 @@ test('project page renders Bandcamp embed and tracklist', async ({ page }) => {
     expect(await tracks.count()).toBeGreaterThan(0)
     await expect(page.locator('.credits')).toBeVisible()
     expect(getErrors()).toEqual([])
+})
+
+test('every song and project Bandcamp embed matches its frontmatter ID exactly', async () => {
+    // Comprehensive companion to the two targeted magnolia-sun checks above:
+    // for every song with released[].bandcampTrackId and every project with
+    // bandcampID, confirm the built page embeds that exact ID string. This
+    // guards the whole catalog (not just one file) against YAML integer
+    // coercion silently swapping in a wrong/truncated ID.
+    const songFiles = await glob('src/songs/*.md')
+    let checkedSongs = 0
+    for (const file of songFiles) {
+        const data = readFrontmatter(file)
+        if (!Array.isArray(data.released)) continue
+        const slug = file.replace(/^src\/songs\//, '').replace(/\.md$/, '')
+        const distPath = resolve(DIST, 'songs', slug, 'index.html')
+        const html = readFileSync(distPath, 'utf8')
+        for (const release of data.released) {
+            if (!release.bandcampTrackId) continue
+            checkedSongs++
+            const id = String(release.bandcampTrackId)
+            const idPattern = new RegExp(`track=${id}\\b`)
+            expect(
+                html,
+                `${distPath} should embed an iframe with track=${id} (from ${file})`
+            ).toMatch(idPattern)
+        }
+    }
+    expect(checkedSongs).toBeGreaterThan(0)
+
+    const projectFiles = await glob('src/projects/*.md')
+    let checkedProjects = 0
+    for (const file of projectFiles) {
+        const data = readFrontmatter(file)
+        if (!data.bandcampID) continue
+        checkedProjects++
+        const slug = file.replace(/^src\/projects\//, '').replace(/\.md$/, '')
+        const distPath = resolve(DIST, 'projects', slug, 'index.html')
+        const html = readFileSync(distPath, 'utf8')
+        const id = String(data.bandcampID)
+        const idPattern = new RegExp(`album=${id}\\b`)
+        expect(html, `${distPath} should embed an iframe with album=${id} (from ${file})`).toMatch(
+            idPattern
+        )
+    }
+    expect(checkedProjects).toBeGreaterThan(0)
 })
 
 test('writing index lists posts and a post page renders', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes #60

- Normalized `src/projects/magnolia-sun.md`'s `bandcampID` from double- to single-quotes. This was the only inconsistency found — all 28 `bandcampTrackId` values across `src/songs/*.md` were already single-quoted, and the other three projects with `bandcampID` (`circle-songs`, `circle-songs-vol-ii`, `lucy-goose`) were already single-quoted too.
- Documented the quoting requirement in `CLAUDE.md`'s Song frontmatter and Project frontmatter sections: Bandcamp IDs are opaque identifiers, not numbers, and must be quoted to avoid YAML integer coercion (silently stripped leading zeros, potential future float-precision loss on very large IDs).
- Added build-time validation in `eleventy.config.js` (in the `projects`/`songs` collection callbacks):
  - Warns if any song's `released[].bandcampTrackId` is not a string.
  - Warns if any project's `bandcampID` is not a string.
  - Warns if a project has exactly one of `bandcampID`/`bandcampUrl` set (per the issue, `project.njk` gates the embed on both being present, so a lone value silently produces no embed).
  - All warnings use `console.warn`, not a hard failure, since this is a data-hygiene guard, not a correctness-critical build step.
- Extended the existing smoke tests (`tests/smoke.spec.js`) to assert the exact Bandcamp ID string appears in the rendered iframe `src` on the `magnolia-sun` song and project pages, so a future regression back to unquoted/coerced IDs would be caught by CI.

## Test plan

- [x] `npm run build` — clean build, dist output byte-identical for embed IDs (verified `album=1983118898` and `track=1765836546` in output)
- [x] Manually introduced unquoted numeric IDs (including a leading-zero case, `0849002684` → confirmed it silently became `849002684`, reproducing the exact bug from the issue) and confirmed all three warnings fire; then reverted
- [x] `npm run test` (Playwright) — 10/10 passing, including the two updated Bandcamp ID assertions
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
