### PR TITLE
Small cleanups: dead npm script, debug filter, include-argument shadowing

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -124,10 +124,6 @@ export default async function (eleventyConfig) {
         excerpt_separator: '+++',
     })
 
-    eleventyConfig.addFilter('log', (value) => {
-        console.log(value)
-    })
-
     // Add RSS feed
     eleventyConfig.addPlugin(feedPlugin, {
         type: 'atom',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "test:nobuild": "playwright test",
         "serve": "PROD=0 eleventy --serve",
         "build": "PROD=1 eleventy",
-        "blog": "node scripts/blog.mjs",
         "lint": "npm run lint:js && npm run lint:md",
         "lint:js": "eslint .",
         "lint:md": "markdownlint .",

--- a/src/_layouts/events.njk
+++ b/src/_layouts/events.njk
@@ -4,17 +4,15 @@
 <div class="stripe-content">
     <h2 class="page-title">{{ title }}</h2>
 
-    {# Upcoming one-off events: include expects `calendarEvents` and `design` #}
-    {% set oneOffEvents = calendarEvents.oneOff %}
+    {% from "includes/events-list.njk" import eventsList with context %}
+    {{ eventsList(calendarEvents.oneOff, 'cards') }}
     {% set recurringEvents = calendarEvents.recurring %}
-    {% set calendarEvents = oneOffEvents %}
-    {% set design = 'cards' %}
-    {% include "includes/events-list.njk" %}
 
     {% if recurringEvents.length %}
     <section class="events-recurring-section" aria-labelledby="recurring-heading">
         <h3 id="recurring-heading" class="events-recurring-heading">Recurring events</h3>
-        {% include "includes/events-recurring-list.njk" %}
+        {% from "includes/events-recurring-list.njk" import recurringEventsList with context %}
+        {{ recurringEventsList(recurringEvents) }}
     </section>
     {% endif %}
 

--- a/src/_layouts/includes/events-list.njk
+++ b/src/_layouts/includes/events-list.njk
@@ -1,5 +1,6 @@
+{% macro eventsList(events, design) %}
 <ul class="event-list event-list--{{ design }}">
-    {% for event in calendarEvents %}
+    {% for event in events %}
         <li class="event-item event-item--{{ event.calendar }}{% if event.isRecurring %} event-item--recurring{% endif %}{% if event.projectImage %} event-item--has-image{% endif %}">
             <div class="event-item-content">
                 <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
@@ -23,3 +24,4 @@
         <li class="events-empty">No upcoming events at the moment.</li>
     {% endfor %}
 </ul>
+{% endmacro %}

--- a/src/_layouts/includes/events-recurring-list.njk
+++ b/src/_layouts/includes/events-recurring-list.njk
@@ -1,5 +1,6 @@
+{% macro recurringEventsList(events) %}
 <ul class="event-list event-list--cards">
-    {% for event in recurringEvents %}
+    {% for event in events %}
     <li class="event-item event-item--recurring{% if event.projectImage %} event-item--has-image{% endif %}">
         <div class="event-item-content">
             <time class="event-date" datetime="{{ event.start | date('yyyy-MM-dd') }}">
@@ -21,3 +22,4 @@
     </li>
     {% endfor %}
 </ul>
+{% endmacro %}

--- a/src/_layouts/project.njk
+++ b/src/_layouts/project.njk
@@ -44,16 +44,14 @@
                 <p class="back-link">
                     <a href="{{ calendarId | calendarWebUrl(calendars) }}" target="_blank" rel="noopener noreferrer">Add to your calendar</a>
                 </p>
-                {# Include expects calendarEvents and design; set locally for this include only #}
-                {% set calendarEvents = projectOneOff %}
-                {% set design = 'cards' %}
-                {% include "includes/events-list.njk" %}
+                {% from "includes/events-list.njk" import eventsList with context %}
+                {{ eventsList(projectOneOff, 'cards') }}
                 {% endif %}
                 {% if projectRecurring.length %}
                 <h3>Recurring events</h3>
                 <p class="events-recurring-intro">See <a href="{{ calendarId | calendarWebUrl(calendars) }}" target="_blank" rel="noopener noreferrer">full calendar</a> for all dates.</p>
-                {% set recurringEvents = projectRecurring %}
-                {% include "includes/events-recurring-list.njk" %}
+                {% from "includes/events-recurring-list.njk" import recurringEventsList with context %}
+                {{ recurringEventsList(projectRecurring) }}
                 {% endif %}
                 <p class="back-link">
                     <a href="/events/">All Events</a>


### PR DESCRIPTION
Fixes #58

Three independent, small cleanups grouped into one PR as the issue requested. Each is its own commit so they can be reviewed/reverted separately.

## 1. Dead npm script
`package.json` declared `"blog": "node scripts/blog.mjs"` but there is no `scripts/` directory anywhere in the repo — running it fails with `MODULE_NOT_FOUND`. Removed the entry (the generator itself is gone, so recreating it wasn't the right fix).

## 2. Unused debug `log` filter
`eleventy.config.js` registered a Nunjucks filter `log` that just does `console.log(value)`. Grepped all of `src/` (`.njk` and `.md`) for `| log` usage — no references anywhere. Removed the filter.

## 3. Include-argument shadowing in events templates
`project.njk` and `events.njk` both did `{% set calendarEvents = ... %}` / `{% set design = ... %}` right before `{% include "includes/events-list.njk" %}`, relying on the include implicitly reading back the same-named globals. `calendarEvents` is actually the site's global calendar data from `src/_data/calendarEvents.js`, so this was shadowing real global data, not just passing arguments. Same pattern for `events-recurring-list.njk` via `recurringEvents`.

Converted both includes to Nunjucks macros with explicit named parameters:
- `events-list.njk` -> `{% macro eventsList(events, design) %}`
- `events-recurring-list.njk` -> `{% macro recurringEventsList(events) %}`

Both call sites (`project.njk`, `events.njk`) now do `{% from "..." import ... with context %}` plus a direct macro call instead of `{% set %}` + `{% include %}`. `with context` keeps the macros' access to global data (`calendars`) and custom filters used inside them (`calendarDisplayName`, `dateEastern`, etc.), which was confirmed working via build output.

`event-item-image.njk` was left as a plain `{% include %}` — it's included from inside the existing `{% for event in ... %}` loop in both macro bodies and reads the loop's `event` variable directly. That's normal Nunjucks scoping, not the shadowing pattern the other two includes had, so converting it would just be churn.

### Events rendering verification (highest-risk part of this issue)
Since `events-list.njk` is shared by both the events page and project pages, I verified both:

- `/events/`: built and diffed against a pre-refactor build. Output is byte-identical except for whitespace where the `{% set %}`/`{% include %}` tags were replaced by macro calls. The recurring event (Violet Pub Sing, with calendar name link and project image) renders correctly.
- `/projects/violet-folk-sings/` (has `calendarId`): same byte-identical diff result. "Recurring events" section renders with the event item, calendar-name link, and project image intact.
- `/projects/paper-plane/` (has `calendarId`, but currently has no scheduled events in its calendar): confirmed 0 event elements render both before and after the refactor — this is pre-existing, unrelated behavior (empty calendar), not a regression.

Also ran the full Playwright suite (`npm run test`) — all 10 tests pass, including "events page renders without crashing" and the internal-link-resolution test.

## Drive-by fix: broken pre-commit hook for .njk files
While committing item 3, `hooks/pre-commit` failed on the `.njk` changes: it runs `npx prettier --check` directly against staged files matching `.njk`, but Prettier has no parser for `.njk` templates (`inferredParser: null`) and errors with "No parser could be inferred" on any `.njk` file passed explicitly — reproducible against unmodified files already on `main` (e.g. `base.njk`), so this was pre-existing and unrelated to this PR's content. `npm run format:check` (the documented gate) was unaffected because Prettier silently skips unsupported extensions in directory-glob mode, only explicit file paths error.

Fixed by dropping `njk` from the hook's `prettier_files` extension list so it matches what `format:check` actually enforces. Verified the fix directly: replayed the exact `.njk` diff from the macro-conversion commit in a scratch worktree and confirmed the old hook exits 1 on it while the fixed hook exits 0. All commits in this PR now pass the (fixed) hook cleanly, no `--no-verify` used.

## Verification steps run
- `npm install`
- `npm run build` — succeeds, no errors
- `npm run lint && npm run format:check` — both pass
- `npm run test` — 10/10 Playwright tests pass
- Confirmed the fixed pre-commit hook passes on the exact `.njk` diff in this PR (see above)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run test` (Playwright) - 10/10 pass
- [x] Manually diffed built `/events/` and both calendar-enabled project pages before/after refactor
- [x] Pre-commit hook passes cleanly on all commits, including the `.njk` macro-conversion commit

Generated with Claude Code
