### PR TITLE
Improve getProjectByName error on unknown project slug

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -42,7 +42,14 @@ export default async function (eleventyConfig) {
 
     // Add a filter to get a project by fileSlug
     eleventyConfig.addFilter('getProjectByName', function (projects, name) {
-        return projects.find((project) => project.fileSlug === name).data
+        const project = projects.find((project) => project.fileSlug === name)
+        if (!project) {
+            throw new Error(
+                `Unknown project "${name}" referenced in a song's released: frontmatter. ` +
+                    `Expected a file at src/projects/${name}.md`
+            )
+        }
+        return project.data
     })
 
     // Add a filter to format dates using date-fns


### PR DESCRIPTION
## Summary
- `getProjectByName` used `.find(...).data`, which throws a generic, unhelpful `TypeError` when a song's `released[].project` frontmatter references a project slug that doesn't exist.
- The filter now checks for a match first and throws a descriptive error naming the bad slug and the expected project file path.
- Failing the build loudly is intentional here (per the issue) — a silent skip would ship a broken page.

Fixes #53

## Evidence

Tested by temporarily pointing `src/songs/almost-here.md`'s `released[0].project` at a nonexistent slug (`nonexistent-project-slug`) and running `npm run build`, then reverting.

**Before:**
```
[11ty] 3. Cannot read properties of undefined (reading 'data') (via TypeError)
[11ty] Original error stack trace: TypeError: Cannot read properties of undefined (reading 'data')
    at Context.<anonymous> (.../eleventy.config.js:45:69)
```
No indication of which file or slug caused it.

**After:**
```
[11ty] 3. Unknown project "nonexistent-project-slug" referenced in a song's released: frontmatter. Expected a file at src/projects/nonexistent-project-slug.md
[11ty] Original error stack trace: Error: Unknown project "nonexistent-project-slug" referenced in a song's released: frontmatter. Expected a file at src/projects/nonexistent-project-slug.md
    at Context.<anonymous> (.../eleventy.config.js:47:19)
```
Clearly names the bad slug and the file path Eleventy expected to find.

## Test plan
- [x] `npm run build` succeeds cleanly with current (valid) project references
- [x] Manually verified the new error message by temporarily pointing a song at a nonexistent project slug, then reverted the scratch edit
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] `npm run test` (Playwright smoke suite) — not verified in this environment; the local sandbox's `http-server` didn't come up reliably for the Playwright `webServer`, causing `ERR_CONNECTION_REFUSED` on all page-navigation tests regardless of this change. This looks like a pre-existing environment limitation, not a regression from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
