### PR TITLE
Add content.spec.js: catch partial frontmatter cross-reference failures

### DIFF
--- a/src/projects/circle-songs-vol-ii.md
+++ b/src/projects/circle-songs-vol-ii.md
@@ -16,11 +16,11 @@ songs:
       lyricsUrl: /songs/royal-potatoes
     - title: Join Me Here
       lyricsUrl: /songs/join-me-here
-    - title: Who Has Seen The Wind?
+    - title: Who Has Seen the Wind?
       lyricsUrl: /songs/who-has-seen-the-wind
-    - title: Holding A Place For You
+    - title: Holding a Place for You
       lyricsUrl: /songs/holding-a-place-for-you
-    - title: Dragons Of Kilpatrick
+    - title: Dragons of Kilpatrick
       lyricsUrl: /songs/dragons-of-kilpatrick
 credits: |
     Lead Vocals: Emma&nbsp;Azelborn  

--- a/tests/content.spec.js
+++ b/tests/content.spec.js
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { glob } from 'glob'
+import yaml from 'js-yaml'
+
+const DIST = resolve('dist')
+const SRC = resolve('src')
+
+// Parses the leading `---`-delimited YAML frontmatter block out of a
+// markdown source file, mirroring how Eleventy reads these files.
+function readFrontmatter(path) {
+    const raw = readFileSync(path, 'utf8')
+    const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/)
+    if (!match) return {}
+    return yaml.load(match[1]) || {}
+}
+
+function slugFromPath(path) {
+    return path.split('/').pop().replace(/\.md$/, '')
+}
+
+// Nunjucks HTML-escapes text output (e.g. "We'll" -> "We&#39;ll"), so decode
+// the small set of entities it can actually produce before comparing titles.
+function decodeHtmlEntities(text) {
+    return text
+        .replace(/&#39;/g, "'")
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+}
+
+async function loadEntries(globPattern) {
+    const files = await glob(globPattern, { cwd: SRC, absolute: true })
+    return files.map((file) => ({
+        slug: slugFromPath(file),
+        file,
+        data: readFrontmatter(file),
+    }))
+}
+
+test.describe('song frontmatter cross-references', () => {
+    test('every released song embeds its exact Bandcamp track id', async () => {
+        const songs = await loadEntries('songs/*.md')
+        const missing = []
+
+        for (const song of songs) {
+            for (const rel of song.data.released || []) {
+                if (!rel.bandcampTrackId) continue
+                const distPath = resolve(DIST, 'songs', song.slug, 'index.html')
+                if (!existsSync(distPath)) {
+                    missing.push(`${song.slug}: dist page missing at ${distPath}`)
+                    continue
+                }
+                const html = readFileSync(distPath, 'utf8')
+                if (!html.includes(`track=${rel.bandcampTrackId}`)) {
+                    missing.push(
+                        `${song.slug}: expected "track=${rel.bandcampTrackId}" in built page`
+                    )
+                }
+            }
+        }
+
+        expect(missing, missing.join('\n')).toEqual([])
+    })
+
+    test('every released song links to its project in the "Appears in" section', async () => {
+        const songs = await loadEntries('songs/*.md')
+        const missing = []
+
+        for (const song of songs) {
+            for (const rel of song.data.released || []) {
+                if (!rel.project) continue
+                const distPath = resolve(DIST, 'songs', song.slug, 'index.html')
+                if (!existsSync(distPath)) {
+                    missing.push(`${song.slug}: dist page missing at ${distPath}`)
+                    continue
+                }
+                const html = readFileSync(distPath, 'utf8')
+                const projectsSection = html.match(/<div class="song-projects">[\s\S]*?<\/div>/)
+                const expectedHref = `/projects/${rel.project}/`
+                if (!projectsSection || !projectsSection[0].includes(`href="${expectedHref}"`)) {
+                    missing.push(
+                        `${song.slug}: expected .song-projects to link to "${expectedHref}"`
+                    )
+                }
+            }
+        }
+
+        expect(missing, missing.join('\n')).toEqual([])
+    })
+})
+
+test.describe('project frontmatter cross-references', () => {
+    test('bandcampID and bandcampUrl are both set or both absent, and the embed matches bandcampID', async () => {
+        const projects = await loadEntries('projects/*.md')
+        const problems = []
+
+        for (const project of projects) {
+            const { bandcampID, bandcampUrl } = project.data
+            const hasId = Boolean(bandcampID)
+            const hasUrl = Boolean(bandcampUrl)
+
+            if (hasId !== hasUrl) {
+                problems.push(
+                    `${project.slug}: half-configured Bandcamp embed (bandcampID=${JSON.stringify(
+                        bandcampID
+                    )}, bandcampUrl=${JSON.stringify(bandcampUrl)}) — project.njk only renders the embed when both are set`
+                )
+                continue
+            }
+
+            if (!hasId) continue
+
+            const distPath = resolve(DIST, 'projects', project.slug, 'index.html')
+            if (!existsSync(distPath)) {
+                problems.push(`${project.slug}: dist page missing at ${distPath}`)
+                continue
+            }
+            const html = readFileSync(distPath, 'utf8')
+            if (!html.includes(`album=${bandcampID}`)) {
+                problems.push(`${project.slug}: expected "album=${bandcampID}" in built page`)
+            }
+        }
+
+        expect(problems, problems.join('\n')).toEqual([])
+    })
+})
+
+test.describe('homepage highlighted projects', () => {
+    test('homepage renders exactly config.highlightedProjects.length cards', async () => {
+        const configRaw = readFileSync(resolve(SRC, '_data/config.yaml'), 'utf8')
+        const config = yaml.load(configRaw)
+        const expectedCount = config.highlightedProjects.length
+
+        const html = readFileSync(resolve(DIST, 'index.html'), 'utf8')
+        const actualCount = (html.match(/class="highlighted-project-item"/g) || []).length
+
+        expect(actualCount).toBe(expectedCount)
+    })
+})
+
+test.describe('project tracklist cross-references', () => {
+    test('every songs[].lyricsUrl resolves to a page whose heading matches songs[].title', async () => {
+        const projects = await loadEntries('projects/*.md')
+        const problems = []
+
+        for (const project of projects) {
+            for (const song of project.data.songs || []) {
+                if (!song.lyricsUrl) continue
+
+                const cleanPath = song.lyricsUrl.replace(/^\/|\/$/g, '')
+                const distPath = resolve(DIST, cleanPath, 'index.html')
+                if (!existsSync(distPath)) {
+                    problems.push(
+                        `${project.slug}: songs[].lyricsUrl "${song.lyricsUrl}" does not resolve to a built page (${distPath})`
+                    )
+                    continue
+                }
+
+                const html = readFileSync(distPath, 'utf8')
+                const headingMatch = html.match(/<h2>([^<]*)<\/h2>/)
+                if (!headingMatch) {
+                    problems.push(
+                        `${project.slug}: page at "${song.lyricsUrl}" has no <h2> heading to check`
+                    )
+                    continue
+                }
+
+                const actualTitle = decodeHtmlEntities(headingMatch[1].trim())
+                if (actualTitle !== song.title) {
+                    problems.push(
+                        `${project.slug}: tracklist entry "${song.title}" links to "${song.lyricsUrl}", but that page's heading is "${actualTitle}"`
+                    )
+                }
+            }
+        }
+
+        expect(problems, problems.join('\n')).toEqual([])
+    })
+})

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -11,6 +11,7 @@ test('homepage loads with highlighted projects', async ({ page }) => {
     await page.goto('/')
     await expect(page).toHaveTitle(/Emma Azelborn/)
     await expect(page.locator('.highlighted-project-item').first()).toBeVisible()
+    expect(await page.locator('.highlighted-project-item').count()).toBe(3)
     expect(getErrors()).toEqual([])
 })
 
@@ -34,7 +35,7 @@ test('project page renders Bandcamp embed and tracklist', async ({ page }) => {
         page.locator('iframe[src*="bandcamp.com/EmbeddedPlayer/album="]').first()
     ).toBeVisible()
     const tracks = page.locator('.project-content ol li')
-    expect(await tracks.count()).toBeGreaterThan(0)
+    expect(await tracks.count()).toBe(11)
     await expect(page.locator('.credits')).toBeVisible()
     expect(getErrors()).toEqual([])
 })


### PR DESCRIPTION
## Summary

Fixes #62

Existing tests (`tests/smoke.spec.js`) only asserted "at least one visible" / "count > 0", which passes even when part of the content silently drops — e.g. one of three homepage cards failing to render, or a project's tracklist entry quietly linking to the wrong song page. This adds `tests/content.spec.js`, a pure file-read test suite (no browser) that reads frontmatter directly from `src/` and cross-checks it against the built `dist/` output, so it runs fast alongside `links.spec.js`/`seo.spec.js`.

### Checks added in `tests/content.spec.js`

1. **Bandcamp track embeds** — for every song with `released[].bandcampTrackId`, asserts the built song page's iframe `src` contains `track=<id>` exactly.
2. **"Appears in" links** — for every song with `released[].project`, asserts the `.song-projects` section links to `/projects/<project>/`.
3. **Bandcamp album embeds + half-configured guard** — for every project, asserts `bandcampID` and `bandcampUrl` are either both set or both absent (since `project.njk` only renders the embed when both are present — a project with just one silently drops the embed with no error). When both are set, asserts the built page's iframe contains `album=<id>` exactly.
4. **Homepage highlighted project count** — asserts `dist/index.html` has *exactly* `config.highlightedProjects.length` `.highlighted-project-item` cards, not just `>= 1`.
5. **Tracklist → song page cross-check** (the strongest check) — for every project's `songs[].lyricsUrl`, asserts the target page exists in `dist/` and its `<h2>` heading matches `songs[].title` exactly. This catches a tracklist entry silently pointing at the wrong song.

While verifying check 5 against real content, it caught a genuine pre-existing bug: three tracklist entries in `src/projects/circle-songs-vol-ii.md` ("Who Has Seen The Wind?", "Holding A Place For You", "Dragons Of Kilpatrick") were title-cased differently than the actual song page titles ("Who Has Seen the Wind?", "Holding a Place for You", "Dragons of Kilpatrick"). Fixed as part of this PR so the new test passes against corrected content.

### `tests/smoke.spec.js` tightening

Per the issue's "Also worth tightening" section, replaced loose assertions with exact counts where the expected value is stable:
- Highlighted projects: `.first().toBeVisible()` → also asserts `count() === 3` (current `config.highlightedProjects.length`)
- magnolia-sun tracklist: `toBeGreaterThan(0)` → `toBe(11)` (current track count)

Left `toBeGreaterThan(0)` in place for genuinely unbounded content (posts list, lyric stanzas).

## Regression sanity check

Verified the new tests actually catch regressions by temporarily injecting three separate defects, rebuilding, and confirming failures with clear messages, then reverting each:

1. Changed `magnolia-sun.md`'s `songs[0].lyricsUrl` from `/songs/getting-easier` to `/songs/trees` → `content.spec.js` failed with: `magnolia-sun: tracklist entry "Getting Easier" links to "/songs/trees", but that page's heading is "Trees"`
2. Changed one `config.highlightedProjects` entry to a nonexistent project title → both the new `content.spec.js` check and the tightened `smoke.spec.js` check failed with `Expected: 3, Received: 2` — exactly the "1 of 3 cards silently dropping" scenario from the issue.
3. Removed `bandcampUrl` from a project that still had `bandcampID` (half-configured embed) → `content.spec.js` failed with: `circle-songs-vol-ii: half-configured Bandcamp embed (bandcampID="3577763146", bandcampUrl=undefined) — project.njk only renders the embed when both are set`

All defects were reverted after confirming the failures; the working tree is clean of injected regressions.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run test` — all 15 tests pass (5 new in `content.spec.js`, 4 existing `smoke.spec.js` incl. 2 tightened, plus `links.spec.js`/`seo.spec.js`)
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Confirmed each new check fails clearly against injected regressions, then reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
