### PR TITLE
Fix lyrics separator docs vs reality; migrate songs to ***

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Songs are Markdown files with lyrics as body content. Key frontmatter fields:
 - `score`: path to PDF in `src/static/scores/`
 - `composer`: credit line
 
-The `lyrics` Nunjucks filter (`eleventy/filters/lyrics.js`) converts the rendered Markdown body into stanza `<div>`s, grouping lines by blank-line separators.
+The `lyrics` Nunjucks filter (`eleventy/filters/lyrics.js`) converts the rendered Markdown body into stanza `<div>`s, grouping lines by blank-line separators. A `***` horizontal rule in the body (via the `lyricsSections` filter) splits the lyrics into a structural (default) section and an optional fully-written-out section, shown behind a "Show full lyrics" toggle. Use `***`, not `---`, for this separator — `---` is also the frontmatter fence delimiter, so reusing it in the body risks parser ambiguity and accidental toggles.
 
 ### Project frontmatter
 

--- a/eleventy/filters/lyrics.js
+++ b/eleventy/filters/lyrics.js
@@ -88,10 +88,18 @@ function stanzasFromHtml(normalized) {
  * structural (default) section and an optional fully-written-out section,
  * each rendered to stanza divs. Songs without a "***" separator only have
  * a structural section.
+ *
+ * `songTitle` is optional and only used to make the build-time log (below)
+ * identify which song gained a toggle.
  */
-function stanzaSections(lyricsHtml) {
+function stanzaSections(lyricsHtml, songTitle) {
     const [structuralHtml, ...rest] = lyricsHtml.split(/<hr\s*\/?>/)
     const fullHtml = rest.join('')
+    if (rest.length > 0) {
+        console.log(
+            `[lyrics] "${songTitle || 'unknown song'}" has a "***" separator — rendering a structural/full lyrics toggle.`
+        )
+    }
     return {
         structural: stanzaHtmlToDivs(structuralHtml),
         full: rest.length > 0 ? stanzaHtmlToDivs(fullHtml) : null,

--- a/src/_layouts/song.njk
+++ b/src/_layouts/song.njk
@@ -31,7 +31,7 @@
         {% elif not released %}
         <p><em>This song is not released yet, but I've been singing it out in the world. Feel free to learn it and sing it with your friends!</em></p>
         {% endif %}
-        {% set lyricsSections = content | lyricsSections %}
+        {% set lyricsSections = content | lyricsSections(title) %}
         <div class="song-lyrics" data-lyrics-view="structural">
             {{ lyricsSections.structural | safe }}
         </div>

--- a/src/songs/along-the-boston-harbor.md
+++ b/src/songs/along-the-boston-harbor.md
@@ -32,7 +32,8 @@ Battery Wharf with the sea wall
 _ending:_
 **Along the Boston Harbor!**
 
----
+<!-- prettier-ignore -->
+***
 
 We saw Long Wharf, the longest wharf
 

--- a/src/songs/its-always-been-about-that.md
+++ b/src/songs/its-always-been-about-that.md
@@ -30,7 +30,8 @@ fighting crime / racist hate
 
 keeping us safe / keeping us scared
 
----
+<!-- prettier-ignore -->
+***
 
 you say it's all about keeping us safe
 **no, it's not about keeping us safe

--- a/src/songs/join-me-here.md
+++ b/src/songs/join-me-here.md
@@ -18,7 +18,8 @@ this front porch…
 this rocking chair…
 this little life…
 
----
+<!-- prettier-ignore -->
+***
 
 this small house is too big for me
 **too big for me

--- a/src/songs/making-a-promise-to-myself.md
+++ b/src/songs/making-a-promise-to-myself.md
@@ -24,7 +24,8 @@ I am living this promise to myself
 I am making a promise to myself
 …
 
----
+<!-- prettier-ignore -->
+***
 
 I am making a promise to myself
 **I am making a promise to myself

--- a/src/songs/the-hall-remembers.md
+++ b/src/songs/the-hall-remembers.md
@@ -21,7 +21,8 @@ call our dances
 sing the chorus
 dance together
 
----
+<!-- prettier-ignore -->
+***
 
 In this hall, we dance together
 **We dance together

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -26,6 +26,45 @@ test('song page renders lyric stanzas and Bandcamp embed when released', async (
     expect(getErrors()).toEqual([])
 })
 
+test('song with a "***" separator renders a structural/full lyrics toggle', async ({ page }) => {
+    const getErrors = trackPageErrors(page)
+    await page.goto('/songs/along-the-boston-harbor/')
+    await expect(page.locator('h2')).toContainText('Along the Boston Harbor')
+
+    const structural = page.locator('.song-lyrics[data-lyrics-view="structural"]')
+    const full = page.locator('.song-lyrics[data-lyrics-view="full"]')
+    await expect(structural).toBeVisible()
+    await expect(full).toHaveCount(1)
+    await expect(full).toBeHidden()
+
+    const toggleButton = page.locator('.song-lyrics-toggle-button')
+    await expect(toggleButton).toBeVisible()
+    await expect(toggleButton).toHaveText('Show full lyrics')
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'false')
+
+    await toggleButton.click()
+    await expect(full).toBeVisible()
+    await expect(structural).toBeHidden()
+    await expect(toggleButton).toHaveText('Show structural lyrics')
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'true')
+
+    expect(getErrors()).toEqual([])
+})
+
+test('song without a separator renders only structural lyrics and no toggle', async ({ page }) => {
+    const getErrors = trackPageErrors(page)
+    await page.goto('/songs/almost-here/')
+    await expect(page.locator('h2')).toContainText('Almost Here')
+
+    const structural = page.locator('.song-lyrics[data-lyrics-view="structural"]')
+    const full = page.locator('.song-lyrics[data-lyrics-view="full"]')
+    await expect(structural).toBeVisible()
+    await expect(full).toHaveCount(0)
+    await expect(page.locator('.song-lyrics-toggle-button')).toHaveCount(0)
+
+    expect(getErrors()).toEqual([])
+})
+
 test('project page renders Bandcamp embed and tracklist', async ({ page }) => {
     const getErrors = trackPageErrors(page)
     await page.goto('/projects/magnolia-sun/')


### PR DESCRIPTION
## Summary

Fixes #59.

The lyrics structural/full toggle is driven by a horizontal rule in a song's markdown body. CLAUDE.md and the `lyrics.js` docblock both documented the separator as `***`, but all five songs currently using the toggle actually used `---`. Since `---` is also the YAML frontmatter fence delimiter, reusing it in the body is brittle in two ways: a stray `---` added as a visual verse break silently creates a hidden-by-default "full lyrics" section with no intent to do so, and it risks confusion with frontmatter parsing near the top of a file.

This migrates the five affected songs to `***` (the token the docs already claimed, and the one that isn't overloaded with frontmatter syntax), rather than just updating the docs to match `---`.

- Migrated `along-the-boston-harbor`, `join-me-here`, `its-always-been-about-that`, `making-a-promise-to-myself`, and `the-hall-remembers` from `---` to `***` as their body separator.
- Added a `<!-- prettier-ignore -->` comment above each `***`. Prettier's markdown printer unconditionally normalizes thematic breaks to `---` outside of list context (verified against Prettier 3.8.1's source — there's no config option for this), which would otherwise silently revert the fix the next time `npm run format` runs. Verified the comment doesn't leak into the rendered HTML or affect the `<hr>`-based split in `lyrics.js`.
- Updated CLAUDE.md's Song frontmatter section to document the `***` separator and explain why `---` is avoided.
- Added a build-time `console.log` in `lyrics.js` when a song's lyrics get split on `***`, so a build's output shows exactly which songs render a toggle — useful for catching an accidental separator.
- Added two Playwright assertions to `tests/smoke.spec.js`:
  - `along-the-boston-harbor` (two-section case): both `data-lyrics-view="structural"` and `data-lyrics-view="full"` sections render, `full` starts hidden, the toggle button is present, and clicking it swaps visibility/text/`aria-pressed`.
  - `almost-here` (single-section case, no separator): no `full` div and no toggle button render at all — this is the assertion that would catch an accidental `---`/`***` in a song with no intended toggle.
- As a necessary side-fix (separate commit): the pre-commit hook ran `prettier --check` against staged `.njk` files, but Prettier has never had a parser for `.njk` — `prettier --check <file>.njk` always errors with "No parser could be inferred" when a path is named explicitly (which is what the hook's `xargs` does), even though whole-repo `prettier --check .` silently skips unrecognized extensions. This meant any commit touching a `.njk` file failed the hook regardless of actual formatting (reproduced against a commit from before this change). Dropped `njk` from the hook's prettier file pattern to match what Prettier actually supports. This was required to commit this PR's one-line `song.njk` change (passing `title` into the `lyricsSections` filter for the build-time log).

## Evidence: stanza counts unchanged by the `---` → `***` migration

Structural/full **content** stanza counts (`<div class="stanza">`, excluding empty-line spacer divs), before and after the migration — identical in every case:

| Song | Structural | Full |
|---|---|---|
| along-the-boston-harbor | 6 | 21 |
| join-me-here | 2 | 4 |
| its-always-been-about-that | 9 | 9 |
| making-a-promise-to-myself | 5 | 5 |
| the-hall-remembers | 3 | 7 |
| almost-here (control, no separator) | 4 | N/A (no toggle) |

Build-time log output after the migration, showing exactly the 5 expected songs and no others:

```
[lyrics] "Along the Boston Harbor" has a "***" separator — rendering a structural/full lyrics toggle.
[lyrics] "It's Always Been About That" has a "***" separator — rendering a structural/full lyrics toggle.
[lyrics] "Join Me Here" has a "***" separator — rendering a structural/full lyrics toggle.
[lyrics] "Making A Promise To Myself" has a "***" separator — rendering a structural/full lyrics toggle.
[lyrics] "The Hall Remembers" has a "***" separator — rendering a structural/full lyrics toggle.
```

## Test plan

- [x] `npm run build` — all five songs render identical structural/full stanza counts before and after the migration
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean (required the prettier-ignore comments; without them `npm run format` reverts `***` back to `---`)
- [x] `npm run test` — all 12 Playwright tests pass, including the 2 new toggle assertions
- [x] Verified `almost-here` (no separator) still renders zero toggle button / zero full section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
